### PR TITLE
Only followup on rawhide builds.

### DIFF
--- a/fedmsg.d/hotness-example.py
+++ b/fedmsg.d/hotness-example.py
@@ -22,6 +22,11 @@ More information about the service that created this bug can be found at:
 config = {
     'hotness.bugzilla.enabled': True,
 
+    # Only followup about real builds with these release suffixes (rawhide)
+    'hotness.followup_suffixes': [
+        'fc23',
+    ],
+
     'hotness.bugzilla': {
         #'user': None,
         #'password': None,

--- a/fedmsg.d/hotness-example.py
+++ b/fedmsg.d/hotness-example.py
@@ -22,11 +22,6 @@ More information about the service that created this bug can be found at:
 config = {
     'hotness.bugzilla.enabled': True,
 
-    # Only followup about real builds with these release suffixes (rawhide)
-    'hotness.followup_suffixes': [
-        'fc23',
-    ],
-
     'hotness.bugzilla': {
         #'user': None,
         #'password': None,


### PR DESCRIPTION
And we define what a rawhide build is in the config.

This will be, like so many other things, a PITA in that when mass branch
time comes along, we'll have to remember to go into the hotness config
and update the suffix to the new rawhide suffix.  Such is life (if we
had a releng microservice that made available what the rawhide tag and
suffix was.. that would be awesome.  We should write that).

This fixes #14.