### PR TITLE
Suppress some errors from rpmbuild and friends.

### DIFF
--- a/fedmsg.d/hotness-example.py
+++ b/fedmsg.d/hotness-example.py
@@ -46,6 +46,12 @@ config = {
         'opts': {'scratch': True},
         'priority': 30,
         'target_tag': 'rawhide',
+
+        # These are errors that we won't scream about.
+        'passable_errors': [
+            # This is the packager's problem, not ours.
+            'unclosed macro or bad line continuation',
+        ],
     },
 
     'hotness.anitya': {


### PR DESCRIPTION
We get lots of errors every now and then from hotness, mostly from failures to
automatically bump the spec and build the srpm.  Most of these are things we
can't do anything about, so no need to email us every day about it.