### PR TITLE
Note on the default message posted on bugzilla about packaging and legal changes

### DIFF
--- a/fedmsg.d/hotness-example.py
+++ b/fedmsg.d/hotness-example.py
@@ -17,6 +17,13 @@ https://fedoraproject.org/wiki/Updates_Policy
 More information about the service that created this bug can be found at:
 
 %(explanation_url)s
+
+
+Please keep in mind that with any upstream change, there may also be packaging
+changes that need to be made. Specifically, please remember that it is your
+responsibility to review the new version to ensure that the licensing is still
+correct and that no non-free or legally problematic items have been added
+upstream.
 """
 
 config = {


### PR DESCRIPTION
This is just a reminder that things may have changed either in the Fedora
packaging guidelines or upstream and that both might need to be adjusted.

Text from spot at:
https://lists.fedoraproject.org/pipermail/legal/2015-February/002577.html