### PR TITLE
Create and attach patches to bz tickets we file.

### DIFF
--- a/hotness/buildsys.py
+++ b/hotness/buildsys.py
@@ -127,8 +127,8 @@ class Koji(object):
             filename = filename.strip()
 
             # Copy the patch out of this doomed dir so bz can find it
-            destination = '/var/tmp/' + filename
-            shutil.move('/'.join([tmp, filename]), destination)
+            destination = os.path.join('/var/tmp', filename)
+            shutil.move(os.path.join(tmp, filename), destination)
 
             return task_id, destination, '[patch] ' + comment
         finally:

--- a/hotness/buildsys.py
+++ b/hotness/buildsys.py
@@ -27,10 +27,6 @@ class Koji(object):
         self.opts = config['opts']
         self.priority = config['priority']
         self.target_tag = config['target_tag']
-        self.passable_errors = config.get('passable_errors', [
-            # This is the packager's problem, not ours.
-            'unclosed macro or bad line continuation',
-        ])
 
     def session_maker(self):
         koji_session = koji.ClientSession(self.server, {'timeout': 3600})
@@ -75,12 +71,8 @@ class Koji(object):
         if err:
             self.log.warning(err)
         if p.returncode != 0:
-            message = 'code %s, cmd %r, err %r'
-            if any([target in err for target in self.passable_errors]):
-                self.log.warning(message, p.returncode, cmd, err)
-            else:
-                self.log.error(message, p.returncode, cmd, err)
-                raise Exception
+            message = 'cmd:  %s\nreturn code:  %r\nstdout:\n%s\nstderr:\n%s'
+            raise Exception(message % (' '.join(cmd), p.returncode, out, err))
         return out
 
     def handle(self, package, upstream, version, rhbz):

--- a/hotness/bz.py
+++ b/hotness/bz.py
@@ -117,8 +117,13 @@ class Bugzilla(object):
             'ids': [bug.bug_id],
         }
         self.log.debug("Following up on bug %r with %r" % (bug.bug_id, update))
-        res = self.bugzilla._proxy.Bug.update(update)
+        self.bugzilla._proxy.Bug.update(update)
         self.log.info("Followed up on bug: %s" % bug.weburl)
+
+    def attach_patch(self, filename, description, bug):
+        self.log.debug("Attaching patch to bug %r" % bug.bug_id)
+        self.bugzilla.attachfile(bug.bug_id, filename, description)
+        self.log.info("Attached patch to bug: %s" % bug.weburl)
 
     def exact_bug(self, **package):
         short_desc_pattern = '%(name)s-%(upstream)s ' % package

--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -180,9 +180,14 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
             self.log.info("Now with #%i, time to do koji stuff" % bz.bug_id)
             try:
                 # Kick off a scratch build..
-                task_id = self.buildsys.handle(package, upstream, version, bz)
+                task_id, patch_filename, description = self.buildsys.handle(
+                    package, upstream, version, bz)
+
                 # Map that koji task_id to the bz ticket we want to pursue.
                 self.triggered_task_ids[task_id] = bz
+
+                # Attach the patch to the ticket
+                self.bugzilla.attach_patch(patch_filename, description, bz)
             except Exception as e:
                 heading = "Failed to kick off scratch build."
                 note = heading + "\n\n" + str(e)

--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -183,9 +183,12 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
                 task_id = self.buildsys.handle(package, upstream, version, bz)
                 # Map that koji task_id to the bz ticket we want to pursue.
                 self.triggered_task_ids[task_id] = bz
-            except Exception:
-                self.log.warning("Failed to kick off scratch build.")
+            except Exception as e:
+                heading = "Failed to kick off scratch build."
+                note = heading + "\n\n" + str(e)
+                self.log.warning(heading)
                 self.log.warning(traceback.format_exc())
+                self.bugzilla.follow_up(note, bz)
 
     def handle_buildsys_scratch(self, msg):
         # Is this a scratch build that we triggered a couple minutes ago?


### PR DESCRIPTION
Also, propagate srpm-creation and koji-kickoff errors to the ticket, instead of
emailing sysadmin-datanommer.

Almost always, this is an error in the specfile and I'd like to make the
packager(s) aware of that since I can't really do anything about it myself.