### PR TITLE
Handle multiply mapped anitya projects.

### DIFF
--- a/hotness/anitya.py
+++ b/hotness/anitya.py
@@ -221,7 +221,7 @@ class Anitya(object):
         data = resp.json()
 
         if 'error' in data:
-            log.error('Anitya error: %r' % data['error'])
+            log.warning('Anitya error: %r' % data['error'])
         else:
             log.info("Check yielded upstream version %s for %s" % (
                 data['version'], data['name']))


### PR DESCRIPTION
It is possible for an anitya project to be mapped to two or more Fedora
packages.  In these cases we will now check the monitoring flag of *each*
one of those packages (not just whichever one appears first in the
list) and then file bugs for each of those packages that **do** want
bugs to be filed.

Fixes #33.