### PR TITLE
Use the root url to check for logged in state

### DIFF
--- a/hotness/anitya.py
+++ b/hotness/anitya.py
@@ -128,7 +128,7 @@ class Anitya(object):
 
     @property
     def is_logged_in(self):
-        response = self.session.get(self.url + '/login/fedora')
+        response = self.session.get(self.url)
         return "logout" in response.text
 
     def login(self, username=None, password=None, openid_insecure=False,


### PR DESCRIPTION
The /login/fedora link may always just redirect the user silently.

Helps with #56, other part of the fix is in anitya.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>