### PR TITLE
Report successful rawhide builds (mostly) once.

### DIFF
--- a/hotness/bz.py
+++ b/hotness/bz.py
@@ -48,12 +48,12 @@ class Bugzilla(object):
         self.log = logging.getLogger('fedmsg')
         default = 'https://partner-bugzilla.redhat.com'
         url = self.config.get('url', default)
-        username = self.config['user']
+        self.username = self.config['user']
         password = self.config['password']
         self.bugzilla = bugzilla.Bugzilla(
             url=url, cookiefile=None, tokenfile=None)
         self.log.info("Logging in to %s" % url)
-        self.bugzilla.login(username, password)
+        self.bugzilla.login(self.username, password)
 
         self.base_query['product'] = self.config['product']
         self.base_query['email1'] = self.config['user']


### PR DESCRIPTION
This fixes #17.

With this code, we'll report successful rawhide builds (mostly) once.

Before, if there were many successive rawhide builds, we would report on
each one in the ticket, resulting in perhaps unwanted spam.  Here, we
check if the latest comment on the ticket was from the-new-hotness and
if it was about a successful rawhide build, then don't follow up with
another comment.

However, we will follow up a second time if, for some reason, the latest
comment is not from us.  We'll assume that that means there is some
abnormal situation with the ticket with respect to which it makes sense
to follow up about this new build.  For instance:

- A package maintainer has commented on the bug that something is screwy
  and needs to be fixed, in which case our followup is relevant.
- Bodhi updates were filed for the stable releases and it commented on
  the bug, so now our *newer* rawhide build is actually relevant (the
  stable releases aren't in sync with rawhide anymore when they would
  have previously been).
- A new upstream release was found by anitya in the interim, and so the
  latest commenter on the bug will be us, but that latest comment won't
  be able a successful rawhide build.  Our new followup will be
  relevant.