### PR TITLE
Handle pkgdb.package.update messages.

### DIFF
--- a/hotness/anitya.py
+++ b/hotness/anitya.py
@@ -214,11 +214,15 @@ class Anitya(object):
         response = self.__send_request(url, method='GET')
         return response.json()
 
-    def search_by_package(self, name):
-        url = '{0}/api/projects/?pattern={1}'.format(self.url, name)
+    def get_project_by_package(self, name):
+        url = '{0}/api/project/Fedora/{1}'.format(self.url, name)
         log.info("Looking for %r via %r" % (name, url))
         response = self.__send_request(url, method='GET')
-        return response.json()
+        if not response.status_code == 200:
+            log.warn('No existing anitya project found mapped to %r' % name)
+            return None
+        else:
+            return response.json()
 
     def update_url(self, project, homepage):
         if not self.is_logged_in:

--- a/hotness/anitya.py
+++ b/hotness/anitya.py
@@ -298,7 +298,6 @@ class Anitya(object):
             err = ' '.join(tag.stripped_strings)
             raise AnityaException(err)
 
-
         log.info('Successfully mapped %r in anitya' % name)
 
     def add_new_project(self, name, homepage):

--- a/hotness/anitya.py
+++ b/hotness/anitya.py
@@ -241,7 +241,7 @@ class Anitya(object):
         if not response.status_code == 200:
             del data['csrf_token']
             raise AnityaException('Bad status code from anitya when '
-                                  'adding project: %r.  Sent %r' % (
+                                  'updating project: %r.  Sent %r' % (
                                       response.status_code, data))
         elif 'Could not' in response.text:
             soup = bs4.BeautifulSoup(response.text, "lxml")

--- a/hotness/anitya.py
+++ b/hotness/anitya.py
@@ -69,7 +69,7 @@ class AnityaAuthException(AnityaException, AuthError):
 
 
 def _parse_service_form(response):
-    parsed = bs4.BeautifulSoup(response.text)
+    parsed = bs4.BeautifulSoup(response.text, "lxml")
     inputs = {}
     for child in parsed.form.find_all(name='input'):
         if child.attrs['type'] == 'submit':
@@ -239,7 +239,7 @@ class Anitya(object):
             raise AnityaException("Couldn't get form to get "
                                   "csrf token %r" % code)
 
-        soup = bs4.BeautifulSoup(response.text)
+        soup = bs4.BeautifulSoup(response.text, "lxml")
         data = dict(
             distro='Fedora',
             package_name=name,
@@ -254,10 +254,12 @@ class Anitya(object):
                                   'mapping package: %r.  Sent %r' % (
                                       response.status_code, data))
         elif 'Could not' in response.text:
-            soup = bs4.BeautifulSoup(response.text)
-            tag = soup.find_all(attrs={'class': 'error'})[0]
+            soup = bs4.BeautifulSoup(response.text, "lxml")
+            # This is the css class on the error flash messages from anitya
+            tag = soup.find_all(attrs={'class': 'list-group-item-danger'})[0]
             err = ' '.join(tag.stripped_strings)
             raise AnityaException(err)
+
 
         log.info('Successfully mapped %r in anitya' % name)
 
@@ -306,11 +308,10 @@ class Anitya(object):
             raise AnityaException("Couldn't get form to get csrf "
                                   "token %r" % code)
 
-        soup = bs4.BeautifulSoup(response.text)
+        soup = bs4.BeautifulSoup(response.text, "lxml")
         data['csrf_token'] = soup.form.find(id='csrf_token').attrs['value']
 
         response = self.__send_request(url, method='POST', data=data)
-
 
         if not response.status_code == 200:
             # Hide this from stuff we republish to the bus
@@ -319,7 +320,7 @@ class Anitya(object):
                                   'adding project: %r.  Sent %r' % (
                                       response.status_code, data))
         elif 'Could not' in response.text:
-            soup = bs4.BeautifulSoup(response.text)
+            soup = bs4.BeautifulSoup(response.text, "lxml")
             tag = soup.find_all(attrs={'class': 'error'})[0]
             err = ' '.join(tag.stripped_strings)
             raise AnityaException(err)

--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -417,23 +417,19 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
         #    a new package (and try to create it and map it)
 
         anitya = hotness.anitya.Anitya(self.anitya_url)
-        results = anitya.search_by_package(name)
-        projects = results['projects']
+        project = anitya.get_project_by_package(name)
 
-        self.log.info("Found %i with name %s" % (len(projects), name))
-
-        if projects:
-            # Our package could be mapped to multiple projects.
+        if project:
+            self.log.info("Found project with name %s" % project['name'])
             anitya.login(self.anitya_username, self.anitya_password)
-            for project in projects:
-                if project['homepage'] == homepage:
-                    self.log.info("No need to update anitya for %s.  Homepages"
-                                  " are already in sync." % project['name'])
-                    continue
+            if project['homepage'] == homepage:
+                self.log.info("No need to update anitya for %s.  Homepages"
+                                " are already in sync." % project['name'])
+                continue
 
-                self.log.info("Updating anitya url on %s" % project['name'])
-                anitya.update_url(project, homepage)
-                anitya.force_check(project)
+            self.log.info("Updating anitya url on %s" % project['name'])
+            anitya.update_url(project, homepage)
+            anitya.force_check(project)
         else:
             # Just pretend like it's a new package, since its not in anitya.
             self.handle_new_package(msg, package)

--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -339,6 +339,16 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
 
         name = listing['package']['name']
         homepage = listing['package']['upstream_url']
+
+        if not homepage:
+            # If there is not homepage set at the outset in pkgdb, there's
+            # nothing smart we can do with respect to anitya, so.. wait.
+            # pkgdb has a cron script that runs weekly that updates the
+            # upstream url there, so when that happens, we'll be triggered
+            # and can try again.
+            self.log.warn("New package %r has no homepage.  Dropping." % name)
+            return
+
         self.log.info("Considering new package %r with %r" % (name, homepage))
 
         anitya = hotness.anitya.Anitya(self.anitya_url)

--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -59,6 +59,10 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
         # we can.
         'org.fedoraproject.prod.pkgdb.package.new',
 
+        # We also look for when packages get their upstream_url changed in
+        # Fedora and try to perform anitya modifications in response.
+        'org.fedoraproject.prod.pkgdb.package.update',
+
         # Lastly, look for packages that get their monitoring flag switched on
         # and off.  We'll use that as another opportunity to map stuff in
         # anitya.
@@ -132,7 +136,13 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
         elif topic.endswith('buildsys.build.state.change'):
             self.handle_buildsys_real(msg)
         elif topic.endswith('pkgdb.package.new'):
-            self.handle_new_package(msg)
+            listing = msg['msg']['package_listing']
+            if listing['collection']['branchname'] != 'master':
+                self.log.debug("Ignoring non-rawhide new package...")
+                return
+            self.handle_new_package(msg, listing['package'])
+        elif topic.endswith('pkgdb.package.update'):
+            self.handle_updated_package(msg)
         elif topic.endswith('pkgdb.package.monitor.update'):
             self.handle_monitor_toggle(msg)
         else:
@@ -331,14 +341,9 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
         self.publish("update.bug.followup", msg=dict(
             trigger=msg, bug=dict(bug_id=bug.bug_id)))
 
-    def handle_new_package(self, msg):
-        listing = msg['msg']['package_listing']
-        if listing['collection']['branchname'] != 'master':
-            self.log.debug("Ignoring non-rawhide new package...")
-            return
-
-        name = listing['package']['name']
-        homepage = listing['package']['upstream_url']
+    def handle_new_package(self, msg, package):
+        name = package['name']
+        homepage = package['upstream_url']
 
         if not homepage:
             # If there is not homepage set at the outset in pkgdb, there's
@@ -352,7 +357,7 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
         self.log.info("Considering new package %r with %r" % (name, homepage))
 
         anitya = hotness.anitya.Anitya(self.anitya_url)
-        results = anitya.search(name, homepage)
+        results = anitya.search_by_homepage(name, homepage)
 
         projects = results['projects']
         total = results['total']
@@ -390,6 +395,48 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
                 trigger=msg,
                 success=not bool(reason),
                 reason=reason))
+
+    def handle_updated_package(self, msg):
+        self.log.info("Handling pkgdb update msg %r" % msg.get('msg_id'))
+
+        fields = msg['msg']['fields']
+        if not 'upstream_url' in fields:
+            self.log.info("Ignoring package edit with no url change.")
+            return
+
+        package = msg['msg']['package']
+        name = package['name']
+        homepage = package['upstream_url']
+
+        self.log.info("Trying url change on %s: %s" % (name, homepage))
+
+        # There are two possible scenarios here.
+        # 1) the package already *is mapped* in anitya, in which case we can
+        #    update the old url there
+        # 2) the package is not mapped there, in which case we handle this like
+        #    a new package (and try to create it and map it)
+
+        anitya = hotness.anitya.Anitya(self.anitya_url)
+        results = anitya.search_by_package(name)
+        projects = results['projects']
+
+        self.log.info("Found %i with name %s" % (len(projects), name))
+
+        if projects:
+            # Our package could be mapped to multiple projects.
+            anitya.login(self.anitya_username, self.anitya_password)
+            for project in projects:
+                if project['homepage'] == homepage:
+                    self.log.info("No need to update anitya for %s.  Homepages"
+                                  " are already in sync." % project['name'])
+                    continue
+
+                self.log.info("Updating anitya url on %s" % project['name'])
+                anitya.update_url(project, homepage)
+                anitya.force_check(project)
+        else:
+            # Just pretend like it's a new package, since its not in anitya.
+            self.handle_new_package(msg, package)
 
     def handle_monitor_toggle(self, msg):
         status = msg['msg']['status']


### PR DESCRIPTION
This should fix #46 and #65.

Sometimes, a new package added to Fedora pkgdb doesn't have an upstream_url
off the bat.  We already guard against that and avoid trying to update
anitya with that empty information.

This new code responds when the pkgdb weekly cronjob goes through and
updates the upstream_url field from a scan of the .spec/srpm information.

Since packagers have indicated that a package has a new upstream url, we
use that to update anitya's homepage information, and potentially map
packages to projects for the first time.

Also, silence some BeautifulSoup warnings.