### PR TITLE
Rename this to match the function definition.

### DIFF
--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -490,7 +490,7 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
             return
 
         anitya = hotness.anitya.Anitya(self.anitya_url)
-        results = anitya.search(name, homepage)
+        results = anitya.search_by_homepage(name, homepage)
         total = results['total']
 
         if total > 1:


### PR DESCRIPTION
We renamed the definition of this and we renamed one other usage, but we forgot this spot.  Getting traceback emails about it.