### PR TITLE
Be a little more aggressive with real build comments.

### DIFF
--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -368,7 +368,7 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
             # Don't followup on bugs that we have just recently followed up on.
             # https://github.com/fedora-infra/the-new-hotness/issues/17
             latest = bug.comments[-1]    # Check just the latest comment
-            target = 'completed http'    # Our comments have this in it
+            target = subtitle            # Our comments have this in it
             me = self.bugzilla.username  # Our comments are, obviously, by us.
             if latest['creator'] == me and target in latest['text']:
                 self.log.info("%s has a recent comment from me." % bug.weburl)


### PR DESCRIPTION
In the 0.6.0 release, we added some functionality that was meant to
reduce spam from the-new-hotness.  It would check the last posted
comment on a ticket it was about to comment on, and if the last
commenter was the-new-hotness, and if it was a build comment, but it
would just abort and not post another one.  This was meant to avoid
situations where someone is doing scratch builds of a package over and
over again, and hotness just sits there spamming their tickets.

There's an unanticipated scenario though:

- [x] anitya notices a new upstream
- [x] hotness files the bug
- [x] hotness kicks off a scratch build
- [x] the scratch build finishes and hotness comments on the bug (correctly)
- [x] a user then does a real build
- [ ] hotness goes to add a comment about the real build **but the last
  commenter was the hotness, commenting about a build**, so it does
  nothing.

We want that last comment to actually go through, but the current code
makes it abort.

The commit in this pull request changes it so that it won't make the
last comment *only if* the preceding comment was about the same kind of
build by the same person.  So hotness's scratch build will get a
comment, and the user's real build will also get a comment.

(Note that subsequent *scratch* builds will still *not* pile up on the
ticket, which is a good thing.  Those are checked via a different code
path.)