### PR TITLE
Fix release-monitoring.org html scraping.

### DIFF
--- a/hotness/anitya.py
+++ b/hotness/anitya.py
@@ -239,7 +239,8 @@ class Anitya(object):
 
         data = copy.copy(project)
         data['homepage'] = homepage
-        data['csrf_token'] = soup.form.find(id='csrf_token').attrs['value']
+        form = soup.find(action='/project/%i/edit' % idx)
+        data['csrf_token'] = form.find(id='csrf_token').attrs['value']
         response = self.__send_request(url, method='POST', data=data)
 
         if not response.status_code == 200:
@@ -285,10 +286,12 @@ class Anitya(object):
                                   "csrf token %r" % code)
 
         soup = bs4.BeautifulSoup(response.text, "lxml")
+        form = soup.find(action='/project/%i/map' % idx)
+        csrf_token = form.find(id='csrf_token').attrs['value']
         data = dict(
             distro='Fedora',
             package_name=name,
-            csrf_token=soup.form.find(id='csrf_token').attrs['value'],
+            csrf_token=csrf_token,
         )
         response = self.__send_request(url, method='POST', data=data)
 
@@ -355,7 +358,8 @@ class Anitya(object):
                                   "token %r" % code)
 
         soup = bs4.BeautifulSoup(response.text, "lxml")
-        data['csrf_token'] = soup.form.find(id='csrf_token').attrs['value']
+        form = soup.find(action='/project/new')  # There are two forms, get one
+        data['csrf_token'] = form.find(id='csrf_token').attrs['value']
 
         response = self.__send_request(url, method='POST', data=data)
 

--- a/hotness/anitya.py
+++ b/hotness/anitya.py
@@ -239,8 +239,7 @@ class Anitya(object):
 
         data = copy.copy(project)
         data['homepage'] = homepage
-        form = soup.find(action='/project/%i/edit' % idx)
-        data['csrf_token'] = form.find(id='csrf_token').attrs['value']
+        data['csrf_token'] = soup.find(id='csrf_token').attrs['value']
         response = self.__send_request(url, method='POST', data=data)
 
         if not response.status_code == 200:
@@ -286,8 +285,7 @@ class Anitya(object):
                                   "csrf token %r" % code)
 
         soup = bs4.BeautifulSoup(response.text, "lxml")
-        form = soup.find(action='/project/%i/map' % idx)
-        csrf_token = form.find(id='csrf_token').attrs['value']
+        csrf_token = soup.find(id='csrf_token').attrs['value']
         data = dict(
             distro='Fedora',
             package_name=name,
@@ -358,8 +356,7 @@ class Anitya(object):
                                   "token %r" % code)
 
         soup = bs4.BeautifulSoup(response.text, "lxml")
-        form = soup.find(action='/project/new')  # There are two forms, get one
-        data['csrf_token'] = form.find(id='csrf_token').attrs['value']
+        data['csrf_token'] = soup.find(id='csrf_token').attrs['value']
 
         response = self.__send_request(url, method='POST', data=data)
 


### PR DESCRIPTION
Kinda ugly here, but login with release-monitoring.org broke when we
added a search form to every page there.

Hotness would try to scrape each page for a form, and then extract the
csrf_token from that form.  Except now, there are **two** forms on every
page, so that scraping broke.

This code updates each attempt at that to look explicitly for the form
it is interested in.