### PR TITLE
Allow mappings for npmjs.com as well as npmjs.org.

### DIFF
--- a/hotness/anitya.py
+++ b/hotness/anitya.py
@@ -23,6 +23,7 @@ backends = {
     'hackage.haskell.org': 'Hackage',
     'launchpad.net': 'launchpad',
     'npmjs.org': 'npmjs',
+    'npmjs.com': 'npmjs',
     'packagist.org': 'Packagist',
     'pear.php.net': 'PEAR',
     'pecl.php.net': 'PECL',

--- a/the-new-hotness.spec
+++ b/the-new-hotness.spec
@@ -9,7 +9,7 @@
 %global modname the-new-hotness
 
 Name:               the-new-hotness
-Version:            0.6.3
+Version:            0.6.4
 Release:            1%{?dist}
 Summary:            Consume anitya fedmsg messages to file bugzilla bugs
 
@@ -58,6 +58,9 @@ rm -rf %{buildroot}%{python2_sitelib}/tests/
 %{python2_sitelib}/the_new_hotness-%{version}*
 
 %changelog
+* Tue Nov 24 2015 Ralph Bean <rbean@redhat.com> - 0.6.4-1
+- new version
+
 * Fri Oct 09 2015 Ralph Bean <rbean@redhat.com> - 0.6.3-1
 - new version
 


### PR DESCRIPTION
Fixes #89.

Running this locally, I was able to get my copy of hotness to create the entry:  https://release-monitoring.org/project/8436/