### PR TITLE
Rewrite topics to handle development mode.

### DIFF
--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -72,6 +72,18 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
     config_key = 'hotness.bugzilla.enabled'
 
     def __init__(self, hub):
+
+        # If we're in development mode, rewrite some of our topics so that
+        # local playback with fedmsg-dg-replay works as expected.
+        if hub.config['environment'] == 'dev':
+            # Keep the original set, but append a duplicate set for local work
+            prefix, env = hub.config['topic_prefix'], hub.config['environment']
+            self.topic = self.topic + [
+                '.'.join([prefix, env] + topic.split('.')[3:])
+                for topic in self.topic
+            ]
+            import pprint; pprint.pprint(self.topic)
+
         super(BugzillaTicketFiler, self).__init__(hub)
 
         if not self._initialized:

--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -82,7 +82,6 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
                 '.'.join([prefix, env] + topic.split('.')[3:])
                 for topic in self.topic
             ]
-            import pprint; pprint.pprint(self.topic)
 
         super(BugzillaTicketFiler, self).__init__(hub)
 


### PR DESCRIPTION
This should solve the problems that @phracek hit trying to test
the-new-hotness locally.

The problem is that:

- the-new-hotness has a list of topics it listens to, hardcoded to prod.
- when you replay a message with ``fedmsg-dg-replay`` it constructs a
  new topic for the replayed message, using your local settings (dev
  settings).
- even when you switch your local environment settings from dev to prod,
  the anitya topics have a different *prefix* -- org.release-monitoring
  instead of org.fedoraproject.

This gets around all that by (at startup time) checking to see if you're
in a dev environment, and if so, it rewrites the topics that
the-new-hotness is *listening* for and adds some appropriate ones so
that fedmsg-dg-replay will work.  This shouldn't affect our prod or stg
setups at all.