### PR TITLE
Make this log statement less verbose.

### DIFF
--- a/hotness/buildsys.py
+++ b/hotness/buildsys.py
@@ -210,8 +210,8 @@ class Koji(object):
             if int(ret_code) != 0:
                 self.log.warn('Comparing package were not successful')
             rh_stuff = rh_app.get_rebasehelper_data()
-        except Exception as ex:
-            self.log.info('Compare packages failed. Reason %s' % str(ex))
+        except Exception:
+            self.log.exception('Compare packages failed.')
         self.log.info(rh_stuff)
 
         return rh_stuff

--- a/hotness/buildsys.py
+++ b/hotness/buildsys.py
@@ -208,7 +208,7 @@ class Koji(object):
             rh_app = Application(cli)
             ret_code = rh_app.run()
             if int(ret_code) != 0:
-                self.log.error('Comparing package were not successful')
+                self.log.warn('Comparing package were not successful')
             rh_stuff = rh_app.get_rebasehelper_data()
         except Exception as ex:
             self.log.info('Compare packages failed. Reason %s' % str(ex))


### PR DESCRIPTION
Any calls to ``log.error`` or ``log.exception`` will generate an email
to the admins of the-new-hotness.  Those are very useful, but if we get
them for non-urgent situations, it can inadvertently train us to not pay
attention to the emails over time.

So, I'd like to propose that we *demote* this log statement to a
warning.  What do you think @phracek?  Should it be kept as an error?