### PR TITLE
Correct another instance of mis-used six.iteritems().

### DIFF
--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -288,7 +288,7 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
                            'See for details' % (package, version)
                     self.bugzilla.follow_up(note, bz)
                     if 'logs' in rh_stuff['build_logs']:
-                        for log in six.iteritems(rh_stuff['build_logs']['logs']):
+                        for log in rh_stuff['build_logs']['logs']:
                             note = 'Build log %s.' % log
                             self.bugzilla.attach_patch(log, note, bz)
                     # Attach rebase-helper logs for another analysis


### PR DESCRIPTION
I'd like @phracek to review this one before it gets merged since it
depends on the structure of the output from rebase-helper.  We found an
erroneous instance like this in #106 and I'm not sure if this is the
same kind of situation or not.

See https://github.com/fedora-infra/the-new-hotness/pull/106#discussion_r55363099