### PR TITLE
This dict expects a 4-tuple everywhere else in the code.

### DIFF
--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -327,7 +327,7 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
                         package, upstream, version, bz)
 
                     # Map that koji task_id to the bz ticket we want to pursue.
-                    self.new_triggered_task_ids[task_id] = [bz, None]
+                    self.new_triggered_task_ids[task_id] = [bz, None, str(upstream), str(package)]
                     # Attach the patch to the ticket
                     self.bugzilla.attach_patch(patch_filename, description, bz)
                 except Exception as e:


### PR DESCRIPTION
... so let's put one in here to keep it consistent.  Other code raises a
traceback like the following without this change:

```python
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/moksha/hub/api/consumer.py", line 191, in _work
    self.consume(message)
  File "/usr/lib/python2.7/site-packages/hotness/consumers.py", line 156, in consume
    self.handle_buildsys_scratch(msg)
  File "/usr/lib/python2.7/site-packages/hotness/consumers.py", line 375, in handle_buildsys_scratch
    self._update_tasks(task_id, state)
  File "/usr/lib/python2.7/site-packages/hotness/consumers.py", line 736, in _update_tasks
    bz, new_state, new_version, package = self.new_triggered_task_ids[task_id]
ValueError: need more than 2 values to unpack
```