### PR TITLE
Handle OSError from 'rm'.

### DIFF
--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -317,12 +317,11 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
                     for log in rh_stuff['logs']:
                         rh_logs = "Log %s provided by rebase-helper." % log
                         self.bugzilla.attach_patch(log, rh_logs, bz)
+
                 os.chdir(cwd)
 
-                try:
+                if os.path.exists(tmp):
                     shutil.rmtree(tmp)
-                except OSError as e:
-                    log.warn("Failed to remove %r - %r" % (tmp, e))
 
                 self.log.info("Now with #%i, time to do koji stuff" % bz.bug_id)
                 try:

--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -318,7 +318,12 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
                         rh_logs = "Log %s provided by rebase-helper." % log
                         self.bugzilla.attach_patch(log, rh_logs, bz)
                 os.chdir(cwd)
-                shutil.rmtree(tmp)
+
+                try:
+                    shutil.rmtree(tmp)
+                except OSError as e:
+                    log.warn("Failed to remove %r - %r" % (tmp, e))
+
                 self.log.info("Now with #%i, time to do koji stuff" % bz.bug_id)
                 try:
                     # Kick off a scratch build..


### PR DESCRIPTION
We're in an exception-handling block here, and, depending on where in the
previous block the exception was raised it is possible that the ``tmp``
directory does not even exist.  So, we have to guard against that and log a
warning.