### PR TITLE
Check if rawhide_version == upstream_version first.

### DIFF
--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -232,8 +232,9 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
             # nothing reasonable we can do.  Notify the world of our failure
             # and go back to the event loop.
             self.log.warn("No rawhide version found for %r" % package)
-            self.publish("update.drop", msg=dict(
-                trigger=msg, reason="rawhide"))
+            if is_monitored:
+                self.publish("update.drop", msg=dict(
+                    trigger=msg, reason="rawhide"))
             return
 
         self.log.info("Comparing upstream %s against repo %s-%s" % (

--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -219,10 +219,6 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
 
         # Is it something that we're being asked not to act on?
         is_monitored = self.is_monitored(package)
-        if not is_monitored:
-            self.log.info("Pkgdb says not to monitor %r.  Dropping." % package)
-            self.publish("update.drop", msg=dict(trigger=msg, reason="pkgdb"))
-            return
 
         # Is it new to us?
         fname = self.yumconfig
@@ -248,6 +244,11 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
         if diff == 1:
             self.log.info("OK, %s is newer than %s-%s" % (
                 upstream, version, release))
+
+            if not is_monitored:
+                self.log.info("Pkgdb says not to monitor %r.  Dropping." % package)
+                self.publish("update.drop", msg=dict(trigger=msg, reason="pkgdb"))
+                return
 
             bz = self.bugzilla.handle(
                 projectid, package, upstream, version, release, url)


### PR DESCRIPTION
This should fix #95.

If rawhide matches upstream, we'll just be silent instead of pestering
maintainers about pkgdb monitoring being turned off.