### PR TITLE
Change the tests to use unittest and add style check

### DIFF
--- a/devel/ansible/roles/hotness-dev/files/fedmsg.d/relay.py
+++ b/devel/ansible/roles/hotness-dev/files/fedmsg.d/relay.py
@@ -7,8 +7,9 @@ config = dict(
             ],
         },
 
-        # This is the input side of the relay to which 'fedmsg-logger' and 'fedmsg-dg-replay' will send messages.
-        # It will just repeat those messages out the 'relay_outbound' endpoint on your own box.
+        # This is the input side of the relay to which 'fedmsg-logger' and
+        # 'fedmsg-dg-replay' will send messages. It will just repeat those
+        # messages out the 'relay_outbound' endpoint on your own box.
         relay_inbound=[
             "tcp://127.0.0.1:2003",
         ],

--- a/devel/ansible/roles/hotness-dev/tasks/main.yml
+++ b/devel/ansible/roles/hotness-dev/tasks/main.yml
@@ -25,6 +25,7 @@
     # https://bugzilla.redhat.com/show_bug.cgi?id=1391461
     - python-copr
     - python-dogpile-cache
+    - python-flake8
     - python2-requests
     - python-sh
     - python-six

--- a/fedmsg.d/base.py
+++ b/fedmsg.d/base.py
@@ -26,7 +26,7 @@ config = dict(
     high_water_mark=0,
     io_threads=1,
 
-    ## For the fedmsg-hub and fedmsg-relay. ##
+    # For the fedmsg-hub and fedmsg-relay. #
 
     # We almost always want the fedmsg-hub to be sending messages with zmq as
     # opposed to amqp or stomp.

--- a/fedmsg.d/hotness-example.py
+++ b/fedmsg.d/hotness-example.py
@@ -32,8 +32,8 @@ config = {
     'hotness.bugzilla.enabled': True,
 
     'hotness.bugzilla': {
-        #'user': None,
-        #'password': None,
+        # 'user': None,
+        # 'password': None,
         'url': 'https://partner-bugzilla.redhat.com',
         'product': 'Fedora',
         'version': 'rawhide',
@@ -65,8 +65,8 @@ config = {
 
     'hotness.anitya': {
         'url': 'https://release-monitoring.org',
-        #'username': '....',
-        #'password': '....',
+        # 'username': '....',
+        # 'password': '....',
     },
 
     'hotness.pkgdb_url': 'https://admin.fedoraproject.org/pkgdb/api',

--- a/fedmsg.d/ssl.py
+++ b/fedmsg.d/ssl.py
@@ -38,7 +38,7 @@ config = dict(
     certnames={
         # In prod/stg, map hostname to the name of the cert in ssldir.
         # Unfortunately, we can't use socket.getfqdn()
-        #"app01.stg": "app01.stg.phx2.fedoraproject.org",
+        # "app01.stg": "app01.stg.phx2.fedoraproject.org",
     },
 
     # A mapping of fully qualified topics to a list of cert names for which

--- a/hotness/anitya.py
+++ b/hotness/anitya.py
@@ -3,10 +3,11 @@ import logging
 
 import bs4
 
-ANITYA_URL = 'https://release-monitoring.org/'
-
 from fedora.client import AuthError
 from fedora.client import OpenIdBaseClient
+
+
+ANITYA_URL = 'https://release-monitoring.org/'
 
 log = logging.getLogger('fedmsg')
 

--- a/hotness/buildsys.py
+++ b/hotness/buildsys.py
@@ -9,7 +9,6 @@ import string
 import subprocess as sp
 import tempfile
 import time
-import six
 
 import koji
 import sh

--- a/hotness/bz.py
+++ b/hotness/bz.py
@@ -25,6 +25,7 @@ import logging
 import bugzilla
 import os
 
+
 class Bugzilla(object):
     base_query = {
         'query_format': 'advanced',

--- a/hotness/helpers.py
+++ b/hotness/helpers.py
@@ -16,15 +16,14 @@
     :contact: opensource@till.name
     :license: GPLv2+
 """
-__docformat__ = "restructuredtext"
-
-#from twisted.internet import reactor
 
 import fnmatch
 import re
 import pprint as pprint_module
 
 import rpm
+
+__docformat__ = "restructuredtext"
 
 pp = pprint_module.PrettyPrinter(indent=4)
 pprint = pp.pprint
@@ -120,12 +119,6 @@ def get_html(url, callback=None, errback=None):
 
             c.perform()
             c.close()
-
-            # this causes a hangug if reactor.run() was already called once
-            #df = getPage(url)
-            #df.addCallback(res.write)
-            #df.addCallback(lambda ignore: reactor.stop())
-            #reactor.run()
 
             data = res.getvalue()
             res.close()

--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,5 @@ setup(
     [moksha.consumer]
     bug_filer = hotness.consumers:BugzillaTicketFiler
     """,
+    test_suite='tests',
 )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,8 +1,14 @@
-from nose.tools import eq_
+"""
+Unit tests for hotness.helpers
+"""
+from __future__ import unicode_literals, absolute_import
 
-import hotness.helpers
+import unittest
 
-class TestHelpers(object):
+from hotness import helpers
+
+
+class TestHelpers(unittest.TestCase):
     def test_upstream_cmp(self):
         cases = [
             ('1',       '2',        -1),
@@ -14,10 +20,7 @@ class TestHelpers(object):
             ('1.0.a',   '1.1',      -1),
         ]
         for v1, v2, result in cases:
-            yield self._check_upstream_cmp, v1, v2, result
-
-    def _check_upstream_cmp(self, v1, v2, result):
-        eq_(hotness.helpers.upstream_cmp(v1, v2), result)
+            self.assertEqual(helpers.upstream_cmp(v1, v2), result)
 
     def test_cmp_upstream_repo(self):
         cases = [
@@ -32,7 +35,4 @@ class TestHelpers(object):
             ('1.1',     ('1.1', '2'),      0),
         ]
         for upstream_v, repo_vr, result in cases:
-            yield self._check_cmp_upstream_repo, upstream_v, repo_vr, result
-
-    def _check_cmp_upstream_repo(self, upstream_v, repo_vr, result):
-        eq_(hotness.helpers.cmp_upstream_repo(upstream_v, repo_vr), result)
+            self.assertEqual(helpers.cmp_upstream_repo(upstream_v, repo_vr), result)

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""This module runs flake8 on the entire code base"""
+
+import os
+import subprocess
+import unittest
+
+
+REPO_PATH = os.path.abspath(
+    os.path.dirname(os.path.join(os.path.dirname(__file__), '../')))
+
+
+class TestStyle(unittest.TestCase):
+    """Run flake8 on the repository directory as part of the unit tests."""
+
+    def test_code_with_flake8(self):
+        """Assert the code is PEP8-compliant"""
+        flake8_command = ['flake8', '--max-line-length', '100', REPO_PATH]
+        self.assertEqual(subprocess.call(flake8_command), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The tests were using nose and not the standard unittest module. This
changes that and the tests are now runnable by using `python setup.py
test`. This also fixes all PEP8 violations found by the new style test.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>