### PR TITLE
Modules now log using their own loggers

### DIFF
--- a/fedmsg.d/logging.py
+++ b/fedmsg.d/logging.py
@@ -1,35 +1,58 @@
 # Setup fedmsg logging.
 # See the following for constraints on this format http://bit.ly/Xn1WDn
-bare_format = "[%(asctime)s][%(name)10s %(levelname)7s] %(message)s"
-
-config = dict(
-    logging=dict(
-        version=1,
-        formatters=dict(
-            bare={
-                "datefmt": "%Y-%m-%d %H:%M:%S",
-                "format": bare_format
+config = {
+    'logging': {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'bare': {
+                # Timestamps are not included by default as journald provides
+                # them. If you want a timestamp, add '[%(asctime)s]' to the
+                # format string.
+                'datefmt': '%Y-%m-%dT%H:%M:%S%z',
+                'format': '[%(name)s %(levelname)s] %(message)s',
             },
-        ),
-        handlers=dict(
-            console={
-                "class": "logging.StreamHandler",
-                "formatter": "bare",
-                "level": "INFO",
-                "stream": "ext://sys.stdout",
+        },
+        'handlers': {
+            'console': {
+                'class': 'logging.StreamHandler',
+                'formatter': 'bare',
+                'level': 'DEBUG',
+                'stream': 'ext://sys.stdout',
             }
-        ),
-        loggers=dict(
-            fedmsg={
-                "level": "INFO",
-                "propagate": False,
-                "handlers": ["console"],
+        },
+        'loggers': {
+            'fedmsg': {
+                'level': 'DEBUG',
+                'propagate': False,
+                'handlers': ['console'],
             },
-            moksha={
-                "level": "INFO",
-                "propagate": False,
-                "handlers": ["console"],
+            'fmn': {
+                'level': 'DEBUG',
+                'propagate': False,
+                'handlers': ['console'],
             },
-        ),
-    ),
-)
+            'hotness': {
+                'level': 'DEBUG',
+                'propagate': False,
+                'handlers': ['console'],
+            },
+            'moksha': {
+                'level': 'DEBUG',
+                'propagate': False,
+                'handlers': ['console'],
+            },
+            'rebasehelper': {
+                'level': 'DEBUG',
+                'propagate': False,
+                'handlers': ['console'],
+            },
+        },
+        # The root logger configuration; this is a catch-all configuration
+        # that applies to all log messages not handled by a different logger
+        'root': {
+            'level': 'INFO',
+            'handlers': ['console'],
+        },
+    },
+}

--- a/hotness/anitya.py
+++ b/hotness/anitya.py
@@ -9,7 +9,9 @@ from fedora.client import OpenIdBaseClient
 
 ANITYA_URL = 'https://release-monitoring.org/'
 
-log = logging.getLogger('fedmsg')
+
+_log = logging.getLogger(__name__)
+
 
 backends = {
     'ftp.debian.org': 'Debian project',
@@ -102,15 +104,15 @@ class Anitya(OpenIdBaseClient):
 
     def search_by_homepage(self, name, homepage):
         url = '{0}/api/projects/?homepage={1}'.format(self.base_url, homepage)
-        log.info("Looking for %r via %r" % (name, url))
+        _log.info("Looking for %r via %r" % (name, url))
         return self.send_request(url, verb='GET')
 
     def get_project_by_package(self, name):
         url = '{0}/api/project/Fedora/{1}'.format(self.base_url, name)
-        log.info("Looking for %r via %r" % (name, url))
+        _log.info("Looking for %r via %r" % (name, url))
         data = self.send_request(url, verb='GET')
         if 'error' in data:
-            log.warn(data.error)
+            _log.warn(data.error)
             return None
         else:
             return data
@@ -147,7 +149,7 @@ class Anitya(OpenIdBaseClient):
                 err = ' '.join(tags[0].stripped_strings)
             raise AnityaException(err)
 
-        log.info('Successfully updated anitya url for %r' % data['name'])
+        _log.info('Successfully updated anitya url for %r' % data['name'])
 
     def force_check(self, project):
         """ Force anitya to check for a new upstream release. """
@@ -156,9 +158,9 @@ class Anitya(OpenIdBaseClient):
         data = self.send_request(url, verb='POST', data=dict(id=idx))
 
         if 'error' in data:
-            log.warning('Anitya error: %r' % data['error'])
+            _log.warning('Anitya error: %r' % data['error'])
         else:
-            log.info("Check yielded upstream version %s for %s" % (
+            _log.info("Check yielded upstream version %s for %s" % (
                 data['version'], data['name']))
 
     def map_new_package(self, name, project):
@@ -198,7 +200,7 @@ class Anitya(OpenIdBaseClient):
                 err = ' '.join(tags[0].stripped_strings)
             raise AnityaException(err)
 
-        log.info('Successfully mapped %r in anitya' % name)
+        _log.info('Successfully mapped %r in anitya' % name)
 
     def add_new_project(self, name, homepage):
         if not self.is_logged_in:
@@ -265,4 +267,4 @@ class Anitya(OpenIdBaseClient):
                 err = ' '.join(tags[0].stripped_strings)
             raise AnityaException(err)
 
-        log.info('Successfully added %r to anitya' % data['name'])
+        _log.info('Successfully added %r to anitya' % data['name'])


### PR DESCRIPTION
Previously, logs nearly all came from the "fedmsg" logger, which is very
confusing. This configures logging for the hotness package and gives
each module its own logger. The timestamp has also been removed by
default since journald keeps timestamps for us. It's easy to add back,
though, and the method is documented in fedmsg.d/logging.py

The old logs looked like:

  [2016-12-06 16:58:28][    fedmsg    INFO] Handling koji...

The new logs look like:

  [hotness.consumers INFO] Handling koji...

Signed-off-by: Jeremy Cline <jeremy@jcline.org>