### PR TITLE
Update usage of the 'userstring' config

### DIFF
--- a/devel/ansible/roles/hotness-dev/tasks/main.yml
+++ b/devel/ansible/roles/hotness-dev/tasks/main.yml
@@ -26,6 +26,7 @@
     - python-copr
     - python-dogpile-cache
     - python-flake8
+    - python-mock
     - python2-requests
     - python-sh
     - python-six

--- a/fedmsg.d/hotness-example.py
+++ b/fedmsg.d/hotness-example.py
@@ -50,8 +50,8 @@ config = {
         'cert': os.path.expanduser('~/.fedora.cert'),
         'ca_cert': os.path.expanduser('~/.fedora-server-ca.cert'),
         'git_url': 'http://pkgs.fedoraproject.org/cgit/rpms/{package}.git',
-        'userstring': ('Upstream Monitor',
-                       '<upstream-release-monitoring@fedoraproject.org>'),
+        # Previously a tuple was accepted for 'userstring' which is deprecated
+        'userstring': 'Upstream Monitor <upstream-release-monitoring@fedoraproject.org>',
         'opts': {'scratch': True},
         'priority': 30,
         'target_tag': 'rawhide',

--- a/hotness/buildsys.py
+++ b/hotness/buildsys.py
@@ -1,6 +1,22 @@
-#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
-from __future__ import print_function
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+"""This provides classes and functions to work with the Fedora build system"""
+from __future__ import absolute_import, print_function
+
 import logging
 import os
 import random
@@ -9,9 +25,11 @@ import string
 import subprocess as sp
 import tempfile
 import time
+import warnings
 
 import koji
 import sh
+import six
 
 from rebasehelper.application import Application
 from rebasehelper.cli import CLI
@@ -29,6 +47,12 @@ class Koji(object):
         self.ca_cert = config['ca_cert']
         self.git_url = config['git_url']
         self.userstring = config['userstring']
+        if not isinstance(self.userstring, six.string_types):
+            msg = ('Using a tuple for "userstring" in "hotness.koji"'
+                   ' is deprecated, please use a string in the format'
+                   ' "Your Name <address@example.com>"')
+            warnings.warn(msg, DeprecationWarning)
+            self.userstring = ' '.join(self.userstring)
         self.opts = config['opts']
         self.priority = config['priority']
         self.target_tag = config['target_tag']

--- a/tests/test_buildsys.py
+++ b/tests/test_buildsys.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+"""Unit tests for :module:`hotness.buildsys`"""
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+
+import mock
+
+from hotness import buildsys
+
+
+class KojiTests(unittest.TestCase):
+
+    def test_initialization_userstring_str(self):
+        """Assert that a string for the 'userstring' config option works"""
+        userstring = 'Jeremy <jeremy@example.com>'
+        mock_config = mock.MagicMock()
+        mock_config.__getitem__.return_value = userstring
+        koji = buildsys.Koji(None, mock_config)
+        self.assertEqual(userstring, koji.userstring)
+
+    def test_initialization_userstring_tuple(self):
+        """Assert that a tuple for the 'userstring' config option works"""
+        userstring = ('Jeremy',  '<jeremy@example.com>')
+        mock_config = mock.MagicMock()
+        mock_config.__getitem__.return_value = userstring
+        koji = buildsys.Koji(None, mock_config)
+        self.assertEqual('Jeremy <jeremy@example.com>', koji.userstring)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The configuration provided in fedmsg.d/ indicates that 'hotness.koji'
accepts a 'userstring' key that is a tuple of (<name>, <email>). However
the code expects it to be a string.

This modifies hotness/buildsys.py to handle both cases and document the
expected type for this key.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>