### PR TITLE
Update the-new-hotness to use Kerberos authentication

### DIFF
--- a/devel/ansible/roles/hotness-dev/files/fedmsg.d/hotness.py
+++ b/devel/ansible/roles/hotness-dev/files/fedmsg.d/hotness.py
@@ -1,4 +1,3 @@
-import os
 import socket
 hostname = socket.gethostname().split('.', 1)[0]
 
@@ -48,8 +47,14 @@ config = {
     'hotness.koji': {
         'server': 'https://koji.fedoraproject.org/kojihub',
         'weburl': 'http://koji.fedoraproject.org/koji',
-        'cert': os.path.expanduser('~/.fedora.cert'),
-        'ca_cert': os.path.expanduser('~/.fedora-server-ca.cert'),
+        # Kerberos configuration to authenticate with Koji. In development
+        # environments, use `kinit <fas-name>@FEDORAPROJECT.ORG` to get a
+        # Kerberos ticket and set all krb_* settings to `None`.
+        'krb_principal': None,
+        'krb_keytab': None,
+        'krb_ccache': None,
+        'krb_proxyuser': None,
+        'krb_sessionopts': {'timeout': 3600, 'krb_rdns': False},
         'git_url': 'http://pkgs.fedoraproject.org/cgit/rpms/{package}.git',
         'userstring': ('Upstream Monitor',
                        '<upstream-release-monitoring@fedoraproject.org>'),

--- a/docs/dev-guide.rst
+++ b/docs/dev-guide.rst
@@ -47,6 +47,12 @@ Before you can run ``the-new-hotness``, you need to add your bugzilla credential
 to the configuration. You can set these credentials in ``~/.fedmsg.d/hotness.py``
 in the virtual machine.
 
+You also need to acquire a valid Kerberos ticket to perform Koji scratch builds.
+You can get this by performing ``kinit <fas-username>@FEDORAPROJECT.ORG``.
+
+.. warning::
+    Services will fail to start if you do not provide valid credentials.
+
 You now have a functional development environment. The message of the day for the virtual machine
 has some helpful tips, but the basic services can be started in the virtual machine with::
 

--- a/fedmsg.d/hotness-example.py
+++ b/fedmsg.d/hotness-example.py
@@ -1,4 +1,3 @@
-import os
 import socket
 hostname = socket.gethostname().split('.', 1)[0]
 
@@ -47,8 +46,14 @@ config = {
     'hotness.koji': {
         'server': 'https://koji.fedoraproject.org/kojihub',
         'weburl': 'http://koji.fedoraproject.org/koji',
-        'cert': os.path.expanduser('~/.fedora.cert'),
-        'ca_cert': os.path.expanduser('~/.fedora-server-ca.cert'),
+        # Kerberos configuration to authenticate with Koji. In development
+        # environments, use `kinit <fas-name>@FEDORAPROJECT.ORG` to get a
+        # Kerberos ticket and use the default settings below.
+        'krb_principal': None,
+        'krb_keytab': None,
+        'krb_ccache': None,
+        'krb_proxyuser': None,
+        'krb_sessionopts': {'timeout': 3600, 'krb_rdns': False},
         'git_url': 'http://pkgs.fedoraproject.org/cgit/rpms/{package}.git',
         # Previously a tuple was accepted for 'userstring' which is deprecated
         'userstring': 'Upstream Monitor <upstream-release-monitoring@fedoraproject.org>',

--- a/hotness/buildsys.py
+++ b/hotness/buildsys.py
@@ -24,6 +24,7 @@ import shutil
 import string
 import subprocess as sp
 import tempfile
+import threading
 import time
 import warnings
 
@@ -37,6 +38,8 @@ from rebasehelper.cli import CLI
 
 _log = logging.getLogger(__name__)
 
+_koji_session_lock = threading.RLock()
+
 
 class Koji(object):
     def __init__(self, consumer, config):
@@ -44,8 +47,13 @@ class Koji(object):
         self.config = config
         self.server = config['server']
         self.weburl = config['weburl']
-        self.cert = config['cert']
-        self.ca_cert = config['ca_cert']
+
+        self.krb_principal = config['krb_principal']
+        self.krb_keytab = config['krb_keytab']
+        self.krb_ccache = config['krb_ccache']
+        self.krb_sessionopts = config['krb_sessionopts']
+        self.krb_proxyuser = config['krb_proxyuser']
+
         self.git_url = config['git_url']
         self.userstring = config['userstring']
         if not isinstance(self.userstring, six.string_types):
@@ -59,9 +67,18 @@ class Koji(object):
         self.target_tag = config['target_tag']
 
     def session_maker(self):
-        koji_session = koji.ClientSession(self.server, {'timeout': 3600})
-        koji_session.ssl_login(self.cert, self.ca_cert, self.ca_cert)
-        return koji_session
+        _log.info('Creating a new Koji session to %s', self.server)
+        with _koji_session_lock:
+            koji_session = koji.ClientSession(self.server, self.krb_sessionopts)
+            result = koji_session.krb_login(
+                principal=self.krb_principal,
+                keytab=self.krb_keytab,
+                ccache=self.krb_ccache,
+                proxyuser=self.krb_proxyuser
+            )
+            if not result:
+                _log.error('Koji kerberos authentication failed')
+            return koji_session
 
     def url_for(self, task_id):
         return self.weburl + '/taskinfo?taskID=%i' % task_id


### PR DESCRIPTION
Koji requires Kerberos authentication now, so this switches
the-new-hotness to use that now.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>