### PR TITLE
Remove rebase-helper

### DIFF
--- a/devel/ansible/roles/hotness-dev/tasks/main.yml
+++ b/devel/ansible/roles/hotness-dev/tasks/main.yml
@@ -17,13 +17,10 @@
     - fedmsg
     - fedmsg-hub
     - fedmsg-relay
+    - fedpkg
     - koji
-    - rebase-helper
     - rpm-python
     - python-bugzilla
-    # we have to explicitly require copr for rebase-helper
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1391461
-    - python-copr
     - python-dogpile-cache
     - python-flake8
     - python-mock

--- a/the-new-hotness.spec
+++ b/the-new-hotness.spec
@@ -33,7 +33,6 @@ Requires:           python-dogpile-cache
 Requires:           fedmsg
 Requires:           python-fedmsg-meta-fedora-infrastructure
 Requires:           python-six
-Requires:           rebase-helper >= 0.8.0
 
 %description
 Fedmsg consumer that listens to release-monitoring.org and files bugzilla bugs


### PR DESCRIPTION
This removes the dependency on rebase-helper in the-new-hotness. It also
fixes several of the commands that the-new-hotness shells out to which
depended on git to have a user configured. Finally, it also gets rid of
the 'userstring' setting in favor of a 'email_user' tuple which makes
configuring git with an author simpler.

Fixes #145

Signed-off-by: Jeremy Cline <jeremy@jcline.org>