### PR TITLE
Gracefully handle removing a directory that's already gone

### DIFF
--- a/hotness/buildsys.py
+++ b/hotness/buildsys.py
@@ -199,4 +199,4 @@ class Koji(object):
             return task_id, destination, '[patch] ' + comment
         finally:
             _log.debug("Removing %r" % tmp)
-            shutil.rmtree(tmp)
+            shutil.rmtree(tmp, ignore_errors=True)


### PR DESCRIPTION
If the git clone fails for whatever reason, it removes the target
directory. The finally block is just supposed to make sure the directory
is gone and shouldn't have a problem if it already is gone.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>