### PR TITLE
Detect backend using package name prefix.

### DIFF
--- a/hotness/anitya.py
+++ b/hotness/anitya.py
@@ -33,17 +33,17 @@ backends = {
     'sourceforge.net': 'Sourceforge',
 }
 
-prefixes = [
-    'drupal7-',
-    'drupal6-',
-    'ghc-',
-    'nodejs-',
-    'php-pear-',
-    'php-pecl-',
-    'php-',
-    'python-',
-    'rubygem-',
-]
+prefixes = {
+    'drupal7-': None,
+    'drupal6-': None,
+    'ghc-': None,
+    'nodejs-': None,
+    'php-pear-': None,
+    'php-pecl-': None,
+    'php-': None,
+    'python-': None,
+    'rubygem-': 'Rubygems',
+}
 
 easy_guesses = [
     'Debian project',
@@ -215,10 +215,18 @@ class Anitya(OpenIdBaseClient):
         )
 
         # Try to guess at what backend to prefill...
-        for target, backend in backends.items():
-            if target in homepage:
+
+        # Start with package prefix first...
+        for prefix, backend in prefixes.items():
+            if name.startswith(prefix) and backend != None:
                 data['backend'] = backend
-                break
+
+        # And try homepage if backend was not detected based on prefix
+        if 'backend' not in data:
+            for target, backend in backends.items():
+                if target in homepage:
+                    data['backend'] = backend
+                    break
 
         if 'backend' not in data:
             raise AnityaException('Could not determine backend '

--- a/hotness/tests/test_anitya.py
+++ b/hotness/tests/test_anitya.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""Unit tests for :mod:`hotness.anitya`."""
+
+import unittest
+
+from hotness import anitya
+
+
+class DetermineBackendTests(unittest.TestCase):
+    """Unit tests for :meth:`hotness.anitya.Anitya.determine_backend`."""
+
+    def test_no_backend_found(self):
+        self.assertRaises(anitya.AnityaException, anitya.determine_backend,
+                          'nonsense-package-name', 'http://example.com/home')
+
+    def test_backend_ruby_prefix(self):
+        """Assert packages with the ``rubygem-`` prefix receive the Rubygems backend."""
+        backend = anitya.determine_backend('rubygem-myproject', 'http://example.com/home')
+        self.assertEqual('Rubygems', backend)
+
+    def test_backend_ruby_homepage(self):
+        """Assert packages with a ``rubygems.org`` homepage receive the Rubygems backend."""
+        backend = anitya.determine_backend('ishouldhaveaprefix-project', 'http://rubygems.org/home')
+        self.assertEqual('Rubygems', backend)


### PR DESCRIPTION
This should resolve #116 (and #100). I implemented only rubygems- prefix support ATM, not sure how exactly other ecosystems works ...

Please note I did not tested the PR at all. I tried to go with Vagrant, but I gave up as soon as it required additional dependencies on my computer (I stumbled up on this already for second time already. Why should I have installed anything except Vagrant on my computer? I thought that Vagrant should shield me of all this).