### PR TITLE
Report SRPM build errors to users

### DIFF
--- a/hotness/buildsys.py
+++ b/hotness/buildsys.py
@@ -163,8 +163,13 @@ class Koji(object):
             new_sources = spec_sources(specfile, tmp)
             compare_sources(old_sources, new_sources)
 
-            output = self.run(
-                ['rpmbuild', '-D', '_sourcedir .', '-D', '_topdir .', '-bs', specfile], cwd=tmp)
+            try:
+                output = sp.check_output(
+                    ['rpmbuild', '-D', '_sourcedir .', '-D', '_topdir .', '-bs', specfile],
+                    cwd=tmp)
+            except sp.CalledProcessError as e:
+                msg = 'Failed to build the SRPM: {stderr}'.format(stderr=e.stderr)
+                raise exceptions.HotnessException(msg)
 
             srpm = os.path.join(tmp, output.strip().split()[-1])
             _log.debug("Got srpm %r" % srpm)

--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -346,9 +346,8 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
                 self.bugzilla.follow_up(str(e), bz)
             except Exception as e:
                 _log.exception(e)
-                note = ("An unexpected error occured creating the scratch build: "
-                        "please report this issue to the-new-hotness issue tracker "
-                        "at https://github.com/fedora-infra/the-new-hotness/issues")
+                note = ("An unexpected error occurred while creating the scratch build "
+                        "and has been automatically reported. Sorry!")
                 self.bugzilla.follow_up(note, bz)
 
     def handle_buildsys_scratch(self, msg):


### PR DESCRIPTION
At the moment, hotness shells out a lot and any time something goes
wrong a base ``Exception`` is raised. This needs to be re-written, but
in the meantime, this will at least let users know when and why an SRPM
failed to build.

Additionally, the generic exception message has been changed because it does actually email me for all the errors.

There aren't any tests (for which I am ashamed), but I want to re-write all this code and the only thing the tests could really do at the moment are assert I'm shelling out and ``Exception`` is raised. 😞 

fixes #171

Signed-off-by: Jeremy Cline <jeremy@jcline.org>