### PR TITLE
Enable the old python-bugzilla behavior for autorefresh

### DIFF
--- a/hotness/bz.py
+++ b/hotness/bz.py
@@ -56,6 +56,7 @@ class Bugzilla(object):
         password = self.config['password']
         self.bugzilla = bugzilla.Bugzilla(
             url=url, cookiefile=None, tokenfile=None)
+        self.bugzilla.bug_autorefresh = True
         _log.info("Logging in to %s" % url)
         self.bugzilla.login(self.username, password)
 


### PR DESCRIPTION
The latest python-bugzilla changed the default value for
bug_autorefresh, which causes it to not fetch bugzilla fields you access
if it wasn't part of the query. This breaks the-new-hotness because the
queries don't include all the fields we use. This turns the old behavior
back on

https://github.com/python-bugzilla/python-bugzilla/blob/v2.1.0/NEWS.md

fixes #179 

Signed-off-by: Jeremy Cline <jeremy@jcline.org>