### PR TITLE
Use subprocess check_output for all commands

### DIFF
--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -21,6 +21,7 @@ Authors:    Ralph Bean <rbean@redhat.com>
 
 import logging
 import socket
+import subprocess
 
 from requests.packages.urllib3.util import retry
 import fedmsg
@@ -344,6 +345,11 @@ class BugzillaTicketFiler(fedmsg.consumers.FedmsgConsumer):
                 self.bugzilla.attach_patch(patch_filename, description, bz)
             except exceptions.HotnessException as e:
                 self.bugzilla.follow_up(str(e), bz)
+            except subprocess.CalledProcessError as e:
+                note = ('Skipping the scratch build because an SRPM could not be built: '
+                        '{cmd} returned {code}: {output}'.format(
+                            cmd=e.cmd, code=e.returncode, output=e.output))
+                self.bugzilla.follow_up(note, bz)
             except Exception as e:
                 _log.exception(e)
                 note = ("An unexpected error occurred while creating the scratch build "


### PR DESCRIPTION
This uses the standard library check_output API and handles any
exception it raises in a single location.

fixes #180

Signed-off-by: Jeremy Cline <jeremy@jcline.org>