### PR TITLE
Add bugzilla API key

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Features
 ^^^^^^^^
 
 * Update documentation (#195)
+* Ude bugzilla API key (#209)
 
 0.10.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Features
 ^^^^^^^^
 
 * Update documentation (#195)
-* Ude bugzilla API key (#209)
+* Use bugzilla API key (#209)
 
 0.10.0
 ------

--- a/devel/ansible/roles/hotness-dev/files/fedmsg.d/hotness.py
+++ b/devel/ansible/roles/hotness-dev/files/fedmsg.d/hotness.py
@@ -34,6 +34,7 @@ config = {
         # NOTE: Set the user and password fields when you set up your dev environment
         "user": None,
         "password": None,
+        "api_key": None,
         "url": "https://partner-bugzilla.redhat.com",
         "product": "Fedora",
         "version": "rawhide",

--- a/devel/ansible/roles/hotness-dev/files/motd
+++ b/devel/ansible/roles/hotness-dev/files/motd
@@ -3,7 +3,7 @@ Welcome to The New Hotness development environment!
 
 To start development you need to do this first:
 
-* add your bugzilla credentials to ~/.fedmsg.d/hotness.py
+* add your bugzilla credentials or API key to ~/.fedmsg.d/hotness.py
 
 * acquire a valid Kerberos ticket by `kinit <fas-username>@FEDORAPROJECT.ORG`
 

--- a/fedmsg.d/hotness-example.py
+++ b/fedmsg.d/hotness-example.py
@@ -33,6 +33,7 @@ config = {
     "hotness.bugzilla": {
         # 'user': None,
         # 'password': None,
+        "api_key": None,
         "url": "https://partner-bugzilla.redhat.com",
         "product": "Fedora",
         "version": "rawhide",

--- a/hotness/bz.py
+++ b/hotness/bz.py
@@ -60,10 +60,25 @@ class Bugzilla(object):
         url = self.config.get("url", default)
         self.username = self.config["user"]
         password = self.config["password"]
-        self.bugzilla = bugzilla.Bugzilla(url=url, cookiefile=None, tokenfile=None)
+        api_key = self.config["api_key"]
+        _log.info("Using BZ URL %s" % url)
+
+        if api_key:
+            self.bugzilla = bugzilla.Bugzilla(
+                url=url, api_key=api_key, cookiefile=None, tokenfile=None
+            )
+        elif self.username and password:
+            self.bugzilla = bugzilla.Bugzilla(
+                url=url,
+                user=self.username,
+                password=password,
+                cookiefile=None,
+                tokenfile=None,
+            )
+        else:
+            self.bugzilla = bugzilla.Bugzilla(url=url, cookiefile=None, tokenfile=None)
+
         self.bugzilla.bug_autorefresh = True
-        _log.info("Logging in to %s" % url)
-        self.bugzilla.login(self.username, password)
 
         self.base_query["product"] = self.config["product"]
         self.base_query["email1"] = self.config["user"]

--- a/hotness/tests/test_bz.py
+++ b/hotness/tests/test_bz.py
@@ -1,0 +1,64 @@
+"""
+Unit tests for hotness.bz
+"""
+import unittest
+import mock
+
+from hotness import bz
+
+
+class TestBugzilla(unittest.TestCase):
+    """
+    Test class for `hotness.bz` class.
+    """
+
+    @mock.patch("hotness.consumers.BugzillaTicketFiler")
+    @mock.patch("hotness.bz.bugzilla.Bugzilla.__init__", return_value=None)
+    def test_init_with_api_key(self, __init__, mock_consumer):
+        """Test the `__init__` method when the config contains an api_key."""
+        mock_config = {
+            "url": "https://example.com/bz",
+            "user": None,
+            "password": None,
+            "api_key": "api_key",
+            "product": "product",
+            "version": "version",
+            "bug_status": "status",
+            "short_desc_template": "short_desc_template",
+            "description_template": "description_template",
+        }
+
+        bz.Bugzilla(mock_consumer, mock_config)
+
+        __init__.assert_called_once_with(
+            url="https://example.com/bz",
+            api_key="api_key",
+            cookiefile=None,
+            tokenfile=None,
+        )
+
+    @mock.patch("hotness.consumers.BugzillaTicketFiler")
+    @mock.patch("hotness.bz.bugzilla.Bugzilla.__init__", return_value=None)
+    def test__connect_with_creds_and_api_key(self, __init__, mock_consumer):
+        """Test the __init__ method when the config contains credentials and an api_key."""
+        mock_config = {
+            "url": "https://example.com/bz",
+            "user": "user",
+            "password": "password",
+            "api_key": "api_key",
+            "product": "product",
+            "version": "version",
+            "bug_status": "status",
+            "short_desc_template": "short_desc_template",
+            "description_template": "description_template",
+        }
+
+        bz.Bugzilla(mock_consumer, mock_config)
+
+        # Using an API key should cause the credentials to be ignored.
+        __init__.assert_called_once_with(
+            url="https://example.com/bz",
+            api_key="api_key",
+            cookiefile=None,
+            tokenfile=None,
+        )


### PR DESCRIPTION
This commit adds support for bugzilla API key. This should help prevent
losing session when using username and password.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>