### PR TITLE
Fix hotness fedora messaging schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Development
 
 * Remove python 2 from tests (#216)
 
+* Fix schema for Fedora messaging (#224)
+
 
 0.11.1
 ------

--- a/hotness/tests/test_consumers.py
+++ b/hotness/tests/test_consumers.py
@@ -264,7 +264,7 @@ class TestConsumer(HotnessTestCase):
             mock_log.info.call_args_list[0][0][0],
         )
 
-        mock_handle_update.assert_called_with("0.17.0", "pg-semver", message.body)
+        mock_handle_update.assert_called_with("0.17.0", "pg-semver", message)
 
     @create_message("anitya.project.map.new", "no_version")
     @mock.patch("hotness.consumers._log")

--- a/hotness_schema/hotness_schema/tests/test_messages.py
+++ b/hotness_schema/hotness_schema/tests/test_messages.py
@@ -26,25 +26,24 @@ class TestUpdateDrop(unittest.TestCase):
 
     def setUp(self):
         """Set up the test environment."""
-        self.message = UpdateDrop()
+        message_body = {
+            "reason": "anitya",
+            "trigger": {
+                "msg": {"message": {"new": "Dummy"}},
+                "topic": "anitya.project.map.new",
+            },
+        }
+        self.message = UpdateDrop(body=message_body)
 
     @mock.patch(
-        "hotness_schema.messages.UpdateDrop.summary", new_callable=mock.PropertyMock
-    )
-    def test__str__(self, mock_property):
-        """Assert correct string is returned."""
-        mock_property.return_value = "Dummy"
-        self.assertEqual(self.message.__str__(), "Dummy")
-
-    @mock.patch(
-        "hotness_schema.messages.UpdateDrop.project", new_callable=mock.PropertyMock
+        "hotness_schema.messages.UpdateDrop.packages", new_callable=mock.PropertyMock
     )
     @mock.patch(
         "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
     )
-    def test_summary_anitya(self, mock_reason, mock_project):
+    def test_summary_anitya(self, mock_reason, mock_packages):
         """Assert correct summary is returned."""
-        mock_project.return_value = "Dummy"
+        mock_packages.return_value = ["Dummy"]
         mock_reason.return_value = "anitya"
         print(self.message.reason)
         exp = (
@@ -55,14 +54,14 @@ class TestUpdateDrop(unittest.TestCase):
         self.assertEqual(self.message.summary, exp)
 
     @mock.patch(
-        "hotness_schema.messages.UpdateDrop.project", new_callable=mock.PropertyMock
+        "hotness_schema.messages.UpdateDrop.packages", new_callable=mock.PropertyMock
     )
     @mock.patch(
         "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
     )
-    def test_summary_rawhide(self, mock_reason, mock_project):
+    def test_summary_rawhide(self, mock_reason, mock_packages):
         """Assert correct summary is returned."""
-        mock_project.return_value = "Dummy"
+        mock_packages.return_value = ["Dummy"]
         mock_reason.return_value = "rawhide"
         print(self.message.reason)
         exp = (
@@ -72,14 +71,14 @@ class TestUpdateDrop(unittest.TestCase):
         self.assertEqual(self.message.summary, exp)
 
     @mock.patch(
-        "hotness_schema.messages.UpdateDrop.project", new_callable=mock.PropertyMock
+        "hotness_schema.messages.UpdateDrop.packages", new_callable=mock.PropertyMock
     )
     @mock.patch(
         "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
     )
-    def test_summary_pkgdb(self, mock_reason, mock_project):
+    def test_summary_pkgdb(self, mock_reason, mock_packages):
         """Assert correct summary is returned."""
-        mock_project.return_value = "Dummy"
+        mock_packages.return_value = ["Dummy"]
         mock_reason.return_value = "pkgdb"
         print(self.message.reason)
         exp = (
@@ -90,14 +89,14 @@ class TestUpdateDrop(unittest.TestCase):
         self.assertEqual(self.message.summary, exp)
 
     @mock.patch(
-        "hotness_schema.messages.UpdateDrop.project", new_callable=mock.PropertyMock
+        "hotness_schema.messages.UpdateDrop.packages", new_callable=mock.PropertyMock
     )
     @mock.patch(
         "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
     )
-    def test_summary_bugzilla(self, mock_reason, mock_project):
+    def test_summary_bugzilla(self, mock_reason, mock_packages):
         """Assert correct summary is returned."""
-        mock_project.return_value = "Dummy"
+        mock_packages.return_value = ["Dummy"]
         mock_reason.return_value = "bugzilla"
         print(self.message.reason)
         exp = (
@@ -107,14 +106,14 @@ class TestUpdateDrop(unittest.TestCase):
         self.assertEqual(self.message.summary, exp)
 
     @mock.patch(
-        "hotness_schema.messages.UpdateDrop.project", new_callable=mock.PropertyMock
+        "hotness_schema.messages.UpdateDrop.packages", new_callable=mock.PropertyMock
     )
     @mock.patch(
         "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
     )
-    def test_summary_dummy(self, mock_reason, mock_project):
+    def test_summary_dummy(self, mock_reason, mock_packages):
         """Assert correct summary is returned."""
-        mock_project.return_value = "Dummy"
+        mock_packages.return_value = ["Dummy"]
         mock_reason.return_value = "Dummy"
         print(self.message.reason)
         exp = (
@@ -123,15 +122,91 @@ class TestUpdateDrop(unittest.TestCase):
         )
         self.assertEqual(self.message.summary, exp)
 
-    def test_project(self):
-        """Assert correct project is returned."""
-        self.message.body = {"trigger": {"msg": {"project": "Dummy"}}}
-        self.assertEqual(self.message.project, "Dummy")
+    @mock.patch(
+        "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
+    )
+    def test_package_reason_anitya_message(self, mock_reason):
+        """
+        Assert correct package is returned, when reason is anitya and body contains
+        message key.
+        """
+        mock_reason.return_value = "anitya"
+        message_body = {
+            "trigger": {
+                "msg": {
+                    "message": {
+                        "packages": [{"distro": "Fedora", "package_name": "Dummy"}]
+                    }
+                }
+            }
+        }
+        with mock.patch.dict(self.message.body, message_body):
+            self.assertEqual(self.message.packages, ["Dummy"])
+
+    @mock.patch(
+        "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
+    )
+    def test_package_reason_anitya_no_packages_in_message(self, mock_reason):
+        """
+        Assert correct package is returned, when reason is anitya and body is
+        missing packages key in message key.
+        """
+        mock_reason.return_value = "anitya"
+        message_body = {
+            "trigger": {
+                "msg": {
+                    "packages": [{"distro": "Fedora", "package_name": "Dummy"}],
+                    "message": "",
+                }
+            }
+        }
+        with mock.patch.dict(self.message.body, message_body):
+            self.assertEqual(self.message.packages, ["Dummy"])
+
+    @mock.patch(
+        "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
+    )
+    def test_package_package_listing(self, mock_reason):
+        """Assert correct package is returned, when package_listing key is available."""
+        mock_reason.return_value = "Dummy"
+        message_body = {
+            "trigger": {"msg": {"package_listing": {"package": {"name": "Dummy"}}}}
+        }
+        with mock.patch.dict(self.message.body, message_body):
+            self.assertEqual(self.message.packages, ["Dummy"])
+
+    @mock.patch(
+        "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
+    )
+    def test_package_buildsys(self, mock_reason):
+        """Assert correct package is returned, when topic contains buildsys.build."""
+        mock_reason.return_value = "Dummy"
+        message_body = {
+            "trigger": {"msg": {"name": "Dummy"}, "topic": "buildsys.build.task.change"}
+        }
+        with mock.patch.dict(self.message.body, message_body):
+            self.assertEqual(self.message.packages, ["Dummy"])
+
+    @mock.patch(
+        "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
+    )
+    def test_package_package(self, mock_reason):
+        """Assert correct package is returned, when package key is available."""
+        mock_reason.return_value = "Dummy"
+        message_body = {
+            "trigger": {
+                "msg": {"package": {"name": "Dummy"}},
+                "topic": "anitya.project.version.update",
+            }
+        }
+        with mock.patch.dict(self.message.body, message_body):
+            self.assertEqual(self.message.packages, ["Dummy"])
 
     def test_reason(self):
         """Assert correct reason is returned."""
-        self.message.body = {"reason": "Dummy"}
-        self.assertEqual(self.message.reason, "Dummy")
+        message_body = {"reason": "Dummy"}
+        with mock.patch.dict(self.message.body, message_body):
+            self.assertEqual(self.message.reason, "Dummy")
 
 
 class TestUpdateBugFile(unittest.TestCase):
@@ -139,26 +214,50 @@ class TestUpdateBugFile(unittest.TestCase):
 
     def setUp(self):
         """Set up the test environment."""
-        self.message = UpdateBugFile()
+        message_body = {
+            "trigger": {
+                "msg": {"message": {"new": "dummy"}},
+                "topic": "anitya.project.map.new",
+            }
+        }
+        self.message = UpdateBugFile(body=message_body)
 
     @mock.patch(
-        "hotness_schema.messages.UpdateBugFile.summary", new_callable=mock.PropertyMock
-    )
-    def test__str__(self, mock_property):
-        """Assert correct string is returned."""
-        mock_property.return_value = "Dummy"
-        self.assertEqual(self.message.__str__(), "Dummy")
-
-    @mock.patch(
-        "hotness_schema.messages.UpdateBugFile.package", new_callable=mock.PropertyMock
+        "hotness_schema.messages.UpdateBugFile.packages", new_callable=mock.PropertyMock
     )
     def test_summary(self, mock_property):
         """Assert correct summary is returned."""
-        mock_property.return_value = "Dummy"
+        mock_property.return_value = ["Dummy"]
         exp = "the-new-hotness filed a bug on 'Dummy'"
         self.assertEqual(self.message.summary, exp)
 
-    def test_package(self):
+    def test_packages_trigger_map_new(self):
         """Assert correct package is returned."""
-        self.message.body = {"package": "Dummy"}
-        self.assertEqual(self.message.package, "Dummy")
+        message_body = {
+            "trigger": {
+                "msg": {"message": {"new": "Dummy"}},
+                "topic": "anitya.project.map.new",
+            }
+        }
+
+        with mock.patch.dict(self.message.body, message_body):
+            self.assertEqual(self.message.packages, ["Dummy"])
+
+    def test_packages_trigger_else(self):
+        """Assert correct packages are returned."""
+        message_body = {
+            "trigger": {
+                "msg": {
+                    "message": {
+                        "packages": [
+                            {"distro": "Fedora", "package_name": "Dummy"},
+                            {"distro": "Fedora", "package_name": "Ordo Hereticus"},
+                        ]
+                    }
+                },
+                "topic": "anitya.project.version.update",
+            }
+        }
+
+        with mock.patch.dict(self.message.body, message_body):
+            self.assertEqual(self.message.packages, ["Dummy", "Ordo Hereticus"])


### PR DESCRIPTION
This should fix the issue with fedmsg_meta_fedora_infrastructure. Which
had trouble parsing the current messages because of the missing values
in trigger object.

I used the same logic for the summary methods as in [fedmsg_meta_fedora_infrastructure](https://github.com/fedora-infra/fedmsg_meta_fedora_infrastructure/blob/develop/fedmsg_meta_fedora_infrastructure/hotness.py).

Fixes #224 

Signed-off-by: Michal Konečný <mkonecny@redhat.com>