### PR TITLE
Nack fedora message when bugzilla error happens

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Bugfixes
 ^^^^^^^^
 
 * Fix crash when error happens during downloading sources (#247)
+* Fix crash when python-bugzilla throws Fault (#255)
 
 
 0.11.9

--- a/hotness/tests/request-data/hotness.tests.test_consumers.TestConsumer.test_handle_anitya_version_update_bugzilla_error
+++ b/hotness/tests/request-data/hotness.tests.test_consumers.TestConsumer.test_handle_anitya_version_update_bugzilla_error
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://apps.fedoraproject.org/mdapi/koji/srcpkg/flatpak
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA9WZX4/aOBDAv4qVJyptDAksu610D709jp602+sdW6lVWyEnMcHFsX22w4Kqfvcb
+        J2GBPUT/CBPdA1I8JvMbxzNje/wlIDqdBy9QsLoeToeD4AIFVMla1HOtJdWGSeHaER7g2Mk05ZQY
+        6mSXeJb2Iyc0ZVEQvXbCl0pxlhIL76GMKi7XBRUWzTQp6IPUCzSTGjrMwkqFiFLGvQ/tVDNlG9iM
+        E6vIAjGDCDJrY2lRvZaUjGdM5BcoY8ZqlpQWWoiIDOlSCPdsoJHIFc02jI+CbC0yCKy6ZaJcYTSh
+        FM2tVeZFt/vAFgznQhYUS51332j5mabWdCcbbTAq40z4KAqpKWICnotKJXb2J/BFBAxwx3gnLjV3
+        EkcBSNNREVxvKsUMDLMG/vPhEwhkYiSnlj4KlJZLltXtL8EBwE9OF2jIndJg9Ffw9QL9R3UHHCIc
+        Dp6dCvGp+tc/JdNPx9JpiKGh3E0L+gVVesNaE2Iz1PSESsLHWoeW6By+UbZnnCg537OuEWxNawQb
+        s1xzb+TdhImumf8flJZGV4rB6XypVms7l6LvSbs3s1dZHmZJaUIInNX6tJCkTBJOHzRRR6Oih2Mc
+        Bcc0B+PRwaCDEDBOSzinXFF96hjcJXKWvCMlNhIPO886w0HC7InDCQgut1tNSRHm0HKwa48wWMnY
+        kjpK1PeHyVzOriD+GLPSVOOIz4H4/e1kNI3x5flQQ2+oPE2nxvPk7DDGNzfTPu6dD9XHkT9Ytpgq
+        tkrKWRjjnqP2PH5EJs9Bgd85MDJxe8VzkFRe1BnOp4PvQMZvxnejaeTTxw/Q/Dn5ZwOra+UWkffJ
+        km7towDym4/2Mbd//Prn5P7vEeTZXjTE0aAdbr8dbEuj9bd2HsX6W0ePYq/awV63gb3Ckb/Ud5wb
+        t8RtxZmvcEvDbSWGrtvCPveGVZIvmA1JToWt4R5X1ga22Xd5x9k5HGKzc1LGMHE3cFTyeS7TZpnH
+        h2oMJ9FuaJrKQnk+xhpZKth3DzzvseoCtG8P2KOAA0zeT+5Hd79B6PqL21XBY89ztEXAmN7d3cZT
+        N2F9f+vqIeDQ1xGmybdu+r6rXlfn4R8rD2rLs8749dvpq5eTVye2v3a6cPPCMdP7vSd1xh6OL4Nj
+        hjce7cPiEyuF+Uvrauhj6j3hhtPdflAxJyLd3uxoCvmxoCJ7ch+ioih0q5uhGiinHWVVHa8vxUIl
+        tSX8G5XsqPcNT72vr3ZMmefUbO+xTKkUp+7a71GUylCRdAE7hEq0U/OuLncaPzpQBt/tsRVkR+Di
+        bred0SXlO4Kg/tRKVnHUjOPrv03SVH34HAAA
+    headers:
+      AppTime:
+      - D=1055917
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '996'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 19 Aug 2019 09:07:20 GMT
+      Keep-Alive:
+      - timeout=15, max=500
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Python/3.6 aiohttp/2.3.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Fedora-ProxyServer:
+      - proxy04.fedoraproject.org
+      X-Fedora-RequestID:
+      - XVpmx9zjT88HkSmAIh6BFwAAAAc
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
This should prevent issue when the-new-hotness is stuck on one message
when bugzilla issue is encountered. Now it should respond with NACK and
return the message back to RabbitMQ queue.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>