### PR TITLE
Increase test coverage

### DIFF
--- a/hotness/buildsys.py
+++ b/hotness/buildsys.py
@@ -31,6 +31,7 @@ import subprocess as sp
 import tempfile
 import threading
 import time
+import typing
 import copy
 
 from six.moves.urllib.parse import urlparse
@@ -299,23 +300,26 @@ class Koji(object):
         )
         return task_id
 
-    def handle(self, package, upstream, version, rhbz):
+    def handle(
+        self, package: str, upstream: str, version: str, rhbz
+    ) -> typing.Tuple[int, str, str]:
         """ Main API entry point.
 
-        Bumps the version on a package and requests a scratch build.
+        Bumps the version of a package and requests a scratch build.
 
         Args:
             package (str): The package name.
             upstream (str): The new upstream version.
             version (str): Unused, exists for API compatibility at the moment.
-            rhbz (?): The bugzilla object with a ``bug_id`` attribute.
+            rhbz (bugzilla.bug.Bug): The bugzilla Bug object with a ``bug_id`` attribute.
 
         Returns:
             tuple: A tuple of (koji task ID, patch path, BZ attachment name).
         """
 
         # Clone the package to a tempdir
-        tmp = tempfile.mkdtemp(prefix="thn-", dir="/var/tmp")
+        # and stop bandit from complaining about a hardcoded temporary directory
+        tmp = tempfile.mkdtemp(prefix="thn-", dir="/var/tmp")  # nosec
         try:
             url = self.git_url.format(package=package)
             _log.info("Cloning %r to %r" % (url, tmp))

--- a/hotness/tests/test_consumers.py
+++ b/hotness/tests/test_consumers.py
@@ -55,7 +55,7 @@ class TestConsumer(HotnessTestCase):
         package = "python-sqlite2"
         expected = True
         actual = self.consumer.is_retired(package)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_is_retired_negative(self):
         """ Ensure that nethack never dies. """
@@ -68,7 +68,7 @@ class TestConsumer(HotnessTestCase):
         package = "nethack"
         expected = False
         actual = self.consumer.is_retired(package)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_is_monitored_negative(self):
         """ Ensure a `no-monitoring` flag in git yields False internally. """
@@ -84,7 +84,7 @@ class TestConsumer(HotnessTestCase):
         package = "php-pecl-timecop"
         expected = False
         actual = self.consumer.is_monitored(package)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_is_monitored_nobuild(self):
         """ Ensure a `monitoring` flag in git yields 'nobuild' internally. """
@@ -100,7 +100,7 @@ class TestConsumer(HotnessTestCase):
         package = "ocaml-cudf"
         expected = "nobuild"
         actual = self.consumer.is_monitored(package)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_is_monitored_positive(self):
         """ Ensure a `monitoring-with-scratch` flag in git yields True
@@ -118,7 +118,7 @@ class TestConsumer(HotnessTestCase):
         package = "xmlrunner"
         expected = True
         actual = self.consumer.is_monitored(package)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_is_in_dist_git(self):
         """ Check that HTTP/200 from dist-git returns True in our helper. """
@@ -130,7 +130,7 @@ class TestConsumer(HotnessTestCase):
         package = "python-requests"
         expected = True
         actual = self.consumer.in_dist_git(package)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_is_not_in_dist_git(self):
         """ Check that HTTP/404 from dist-git returns False in our helper. """
@@ -142,7 +142,7 @@ class TestConsumer(HotnessTestCase):
         package = "not-a-real-package"
         expected = False
         actual = self.consumer.in_dist_git(package)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     @mock.patch("hotness.consumers.BugzillaTicketFiler.handle_anitya_version_update")
     def test_call_anitya_update(self, mock_method):


### PR DESCRIPTION
I have added some unit tests for the `buildsys.Koji` module: they mostly rely on mocking function calls and I am not 100% happy about them currently (as they are not really "deep") but I don't know a better way how to add tests without running a fully fledged integration test suite.