### PR TITLE
Fix rtd build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,22 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: dev-requirements.txt
+    - method: pip
+      path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -356,4 +356,4 @@ texinfo_documents = [
 
 
 # -- Mock required libraries depending on C modules ------------------------------
-autodoc_mock_imports = ['koji']
+autodoc_mock_imports = ["koji"]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
-from setuptools import setup, find_packages
+
+import os
 import re
+
+from setuptools import find_packages, setup
+
+
+ON_READ_THE_DOCS = os.environ.get("READTHEDOCS") == "True"
 
 
 def get_version():
@@ -23,8 +29,22 @@ def get_requirements(requirements_file="requirements.txt"):
     :return type: list
     """
 
-    lines = open(requirements_file).readlines()
-    return [line.rstrip().split("#")[0] for line in lines if not line.startswith("#")]
+    if ON_READ_THE_DOCS:
+        # These packages are not needed to build on Read the Docs
+        ignored_packages = {"koji"}
+    else:
+        ignored_packages = {}
+
+    lines = [
+        line.rstrip().split("#")[0]
+        for line in open(requirements_file).readlines()
+    ]
+    return [
+        line
+        for line in lines
+        if not line.startswith("#")
+        if line not in ignored_packages
+    ]
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,7 @@ def get_requirements(requirements_file="requirements.txt"):
         ignored_packages = {}
 
     lines = [
-        line.rstrip().split("#")[0]
-        for line in open(requirements_file).readlines()
+        line.rstrip().split("#")[0] for line in open(requirements_file).readlines()
     ]
     return [
         line


### PR DESCRIPTION
koji isn't needed to build the documentation and it's being mocked on docs/conf.py. I'm skipping the dep only on rtd. Also, adding a configuration file, so it's easy to configure the build.

Closes #264