### PR TITLE
Drop python 3.5 support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Development
 
 * Fix docs building (#264)
 * Change coverage threshold to be less strict (#273)
+* Remove python 3.5 support (#272)
 
 
 0.12.0

--- a/setup.py
+++ b/setup.py
@@ -58,4 +58,5 @@ setup(
     tests_require=get_requirements("dev-requirements.txt"),
     packages=find_packages(exclude=("hotness.tests", "hotness.tests.*")),
     test_suite="hotness.tests",
+    python_requires=">=3.6",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,lint,format,diff-cover,docs,bandit
+envlist = py36,py37,lint,format,diff-cover,docs,bandit
 
 [testenv]
 deps =


### PR DESCRIPTION
Because rpm dependency no longer supports python 3.5 remove python 3.5
support.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>