### PR TITLE
Fixes and tests for helpers.secure_download

### DIFF
--- a/devel/ansible/roles/hotness-dev/tasks/main.yml
+++ b/devel/ansible/roles/hotness-dev/tasks/main.yml
@@ -4,6 +4,8 @@
   dnf:
     name: [
       git,
+      libcurl-devel,
+      openssl-devel,
       ngrep,
       nmap-ncat,
       python3-rpdb,

--- a/hotness/helpers.py
+++ b/hotness/helpers.py
@@ -325,7 +325,7 @@ def filter_dict(d, key_list):
 
 def secure_download(url, cainfo=""):
     import pycurl
-    import StringIO
+    import io
 
     c = pycurl.Curl()
     c.setopt(pycurl.URL, url.encode("ascii"))
@@ -343,7 +343,7 @@ def secure_download(url, cainfo=""):
     if cainfo:
         c.setopt(pycurl.CAINFO, cainfo)
 
-    res = StringIO.StringIO()
+    res = io.StringIO()
 
     c.setopt(pycurl.WRITEFUNCTION, res.write)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ fedora-messaging
 bs4
 fedmsg
 python-fedora
+pycurl

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ commands =
     rm -rf htmlcov coverage.xml
     py.test -vv --cov-config .coveragerc --cov=hotness --cov=hotness_schema/hotness_schema \
     --cov-report term --cov-report xml --cov-report html {posargs}
+setenv =
+    PYCURL_SSL_LIBRARY = openssl
 passenv = HOME
 
 [testenv:diff-cover]


### PR DESCRIPTION
StringIO has been replaced with io.StringIO, the former no longer exists in Python3.

This adds pycurl as an explicit requirement. pycurl is now required to be available in the tox environment, which in turn requires both libcurl-devel and openssl-devel installed in the vagrant environment. pycurl is told to use the correct ssl library by setting the PYCURL_SSL_LIBRARY in tox.ini.
