### PR TITLE
Fix crash on empty config section

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Bugfixes
 ^^^^^^^^
 
 * Use fallback rpm comparison when rpm module is unavailable (#273)
+* Configuration load crash on empty section (#290)
 
 Development
 ^^^^^^^^^^^

--- a/hotness/buildsys.py
+++ b/hotness/buildsys.py
@@ -230,7 +230,6 @@ def list_to_series(items, N=3, oxford_comma=True):
 class Koji(object):
     def __init__(self, consumer, config):
         self.consumer = consumer
-        self.config = config
         self.server = config["server"]
         self.weburl = config["weburl"]
 

--- a/hotness/bz.py
+++ b/hotness/bz.py
@@ -56,10 +56,9 @@ class Bugzilla(object):
     def __init__(self, consumer, config):
         self.consumer = consumer
         self.config = config
-        default = "https://partner-bugzilla.redhat.com"
-        url = self.config.get("url", default)
+        url = self.config["url"]
         self.username = self.config["user"]
-        self.reporter = self.config.get("reporter", "Upstream Release Monitoring")
+        self.reporter = self.config["reporter"]
         password = self.config["password"]
         api_key = self.config["api_key"]
         _log.info("Using BZ URL %s" % url)

--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -61,38 +61,38 @@ class BugzillaTicketFiler(object):
 
     def __init__(self):
         self.bugzilla = hotness.bz.Bugzilla(
-            consumer=self, config=hotness_config["BUGZILLA"]
+            consumer=self, config=hotness_config["bugzilla"]
         )
         self.buildsys = hotness.buildsys.Koji(
-            consumer=self, config=hotness_config["KOJI"]
+            consumer=self, config=hotness_config["koji"]
         )
 
-        self.pdc_url = hotness_config["PDC_URL"]
-        self.dist_git_url = hotness_config["DIST_GIT_URL"]
+        self.pdc_url = hotness_config["pdc_url"]
+        self.dist_git_url = hotness_config["dist_git_url"]
 
-        self.anitya_url = hotness_config["ANITYA"]["url"]
+        self.anitya_url = hotness_config["anitya"]["url"]
 
         # Also, set up our global cache object.
         _log.info("Configuring cache.")
         with hotness.cache.cache_lock:
             if not hotness.cache.cache.is_configured:
-                hotness.cache.cache.configure(**hotness_config["CACHE"])
+                hotness.cache.cache.configure(**hotness_config["cache"])
 
-        self.mdapi_url = hotness_config["MDAPI_URL"]
+        self.mdapi_url = hotness_config["mdapi_url"]
         _log.info("Using hotness.mdapi_url=%r" % self.mdapi_url)
-        self.repoid = hotness_config["REPOID"]
+        self.repoid = hotness_config["repoid"]
         _log.info("Using hotness.repoid=%r" % self.repoid)
-        self.distro = hotness_config["DISTRO"]
+        self.distro = hotness_config["distro"]
         _log.info("Using hotness.distro=%r" % self.distro)
 
         # Retrieve the requests configuration; by default requests time out
         # after 15 seconds and are retried up to 3 times.
         self.requests_session = requests.Session()
         self.timeout = (
-            hotness_config["CONNECT_TIMEOUT"],
-            hotness_config["READ_TIMEOUT"],
+            hotness_config["connect_timeout"],
+            hotness_config["read_timeout"],
         )
-        retries = hotness_config["REQUESTS_RETRIES"]
+        retries = hotness_config["requests_retries"]
         retry_conf = retry.Retry(
             total=retries, connect=retries, read=retries, backoff_factor=1
         )

--- a/hotness/tests/test_bz.py
+++ b/hotness/tests/test_bz.py
@@ -26,6 +26,7 @@ class TestBugzilla(unittest.TestCase):
             "product": "product",
             "version": "version",
             "bug_status": "status",
+            "reporter": "Upstream release monitoring",
             "short_desc_template": "short_desc_template",
             "description_template": "description_template",
         }
@@ -44,6 +45,7 @@ class TestBugzilla(unittest.TestCase):
             "product": "product",
             "version": "version",
             "bug_status": "status",
+            "reporter": "Upstream release monitoring",
             "short_desc_template": "short_desc_template",
             "description_template": "description_template",
         }
@@ -69,6 +71,7 @@ class TestBugzilla(unittest.TestCase):
             "product": "product",
             "version": "version",
             "bug_status": "status",
+            "reporter": "Upstream release monitoring",
             "short_desc_template": "short_desc_template",
             "description_template": "description_template",
         }
@@ -94,7 +97,7 @@ class TestBugzilla(unittest.TestCase):
             "emailtype1": "exact",
             "component": "test",
             "bug_status": ["ASSIGNED", "NEW", "status"],
-            "creator": "Upstream Release Monitoring",
+            "creator": "Upstream release monitoring",
             "product": "product",
             "email1": None,
         }

--- a/hotness/tests/test_config.py
+++ b/hotness/tests/test_config.py
@@ -46,6 +46,7 @@ full_config = {
             "keywords": "",
             "bug_status": "",
             "explanation_url": "https://fedoraproject.org/wiki/upstream_release_monitoring_test",
+            "reporter": "",
             "short_desc_template": "",
             "description_template": "",
         },
@@ -56,25 +57,27 @@ full_config = {
             "krb_keytab": "krb_keytab",
             "krb_ccache": "krb_ccache",
             "krb_proxyuser": "krb_proxyuser",
-            "krb_sessionopts": {},
+            "krb_sessionopts": {"timeout": 600, "krb_rdns": True},
             "git_url": "https://src.stg.fedoraproject.org/cgit/rpms/{package}.git",
             "user_email": [],
-            "opts": {},
+            "opts": {"scratch": False},
             "priority": 60,
             "target_tag": "",
             "passable_errors": [],
         },
         "anitya": {"url": "https://release-monitoring.org/test"},
-        "cache": {"backend": "", "expiration_time": 0, "arguments": {}},
+        "cache": {"backend": "", "expiration_time": 0, "arguments": {"filename": ""}},
     }
 }
 
 empty_config = {"consumer_config": {}}
 
+empty_dict_config = {"consumer_config": {"bugzilla": {}}}
+
 bad_config = {"consumer_config": {"example_key": "value"}}
 
 
-class LoadTests(unittest.TestCase):
+class TestLoad(unittest.TestCase):
     """
     Class for testing the `hotness.config.load` function.
     """
@@ -86,14 +89,20 @@ class LoadTests(unittest.TestCase):
         Assert that config will be changed when correct dictionary is provided.
         """
         config = hotness_config.load(full_config)
-        for key in full_config["consumer_config"]:
-            self.assertEqual(config[key.upper()], full_config["consumer_config"][key])
+        self.assertEqual(config, full_config["consumer_config"])
 
     def test_load_empty_config(self):
         """
         Assert that default values will be used when empty dictionary is provided.
         """
         config = hotness_config.load(empty_config)
+        self.assertEqual(config, hotness_config.DEFAULTS)
+
+    def test_load_empty_inner_dict(self):
+        """
+        Assert that default values will be used when empty inner dictionary is provided.
+        """
+        config = hotness_config.load(empty_dict_config)
         self.assertEqual(config, hotness_config.DEFAULTS)
 
     def test_load_bad_config(self):


### PR DESCRIPTION
This fix is rather complex, so I split it to smaller parts:
1) Add recursive load of config dictionaries, this will ensure that
   every config option we know will be available and we don't end up
   with crash on empty dictionary
2) As direct reaction to the above default case sensitivity was changed
   to lower, because this caused issues when passing arguments as dictionary to
   3rd party libs
3) The copy of the config was changed to deep copy to also copy internal
   dictionaries

Signed-off-by: Michal Konečný <mkonecny@redhat.com>