### PR TITLE
Change links to update policy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Development
 * Remove python 3.5 support (#272)
 * Remove unused functions (#280)
 * Clean and raise coverage for Anitya module (#281)
+* Change links to update policy (#291)
 
 Features
 ^^^^^^^^

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -97,7 +97,7 @@ URL: %(url)s
 
 Please consult the package updates policy before you
 issue an update to a stable branch:
-https://fedoraproject.org/wiki/Updates_Policy
+https://docs.fedoraproject.org/en-US/fesco/Updates_Policy
 
 
 More information about the service that created this bug can be found at:

--- a/devel/ansible/roles/hotness-dev/files/config.toml
+++ b/devel/ansible/roles/hotness-dev/files/config.toml
@@ -95,7 +95,7 @@ URL: %(url)s
 
     Please consult the package updates policy before you
 issue an update to a stable branch:
-    https://fedoraproject.org/wiki/Updates_Policy
+    https://docs.fedoraproject.org/en-US/fesco/Updates_Policy
 
 
 More information about the service that created this bug can be found at:

--- a/fedmsg.d/hotness-example.py
+++ b/fedmsg.d/hotness-example.py
@@ -11,7 +11,7 @@ URL: %(url)s
 
 Please consult the package updates policy before you
 issue an update to a stable branch:
-https://fedoraproject.org/wiki/Updates_Policy
+https://docs.fedoraproject.org/en-US/fesco/Updates_Policy
 
 
 More information about the service that created this bug can be found at:

--- a/hotness/config.py
+++ b/hotness/config.py
@@ -73,7 +73,7 @@ URL: %(url)s
 
     Please consult the package updates policy before you
 issue an update to a stable branch:
-    https://fedoraproject.org/wiki/Updates_Policy
+    https://docs.fedoraproject.org/en-US/fesco/Updates_Policy
 
 
 More information about the service that created this bug can be found at:


### PR DESCRIPTION
Change the links to the update policy to point to the fedora docs site instead of the wiki.