### PR TITLE
Handle master -> rawhide branch change

### DIFF
--- a/hotness/consumers.py
+++ b/hotness/consumers.py
@@ -430,7 +430,7 @@ class BugzillaTicketFiler(object):
         exceptions raised by that function.
         """
         url = "{0}/rest_api/v1/component-branches/".format(self.pdc_url)
-        params = dict(name="master", global_component=package, type="rpm", active=True)
+        params = dict(name="rawhide", global_component=package, type="rpm", active=True)
         _log.debug("Checking %r to see if %s is retired, %r" % (url, package, params))
         r = self.requests_session.get(url, params=params, timeout=self.timeout)
 
@@ -438,7 +438,7 @@ class BugzillaTicketFiler(object):
             _log.warning("URL %s returned code %s", r.url, r.status_code)
             return True
 
-        # If there are zero active master branches for this package, then it is
+        # If there are zero active rawhide branches for this package, then it is
         # retired.
         return r.json()["count"] == 0
 

--- a/news/316.bug
+++ b/news/316.bug
@@ -1,1 +1,0 @@
-Crash with the new API in Anitya

--- a/news/318.bug
+++ b/news/318.bug
@@ -1,0 +1,1 @@
+handle master -> rawhide branch change


### PR DESCRIPTION
Fedora changed the master branch to rawhide. This change should fix the
issue related to this change, when package was considered retired,
because there was no master branch.

Also remove the news file, which was forgotten in latest release.

Fixes #318

Signed-off-by: Michal Konečný <mkonecny@redhat.com>