### PR TITLE
Fix patch file handling in koji builder

### DIFF
--- a/hotness/builders/koji.py
+++ b/hotness/builders/koji.py
@@ -182,7 +182,8 @@ class Koji(Builder):
             output["patch_filename"] = filename
 
             # Copy the content of file to output
-            with open(filename) as f:
+            patch = os.path.join(tmp, filename)
+            with open(patch) as f:
                 output["patch"] = f.read()
 
             return output

--- a/tests/builders/test_koji.py
+++ b/tests/builders/test_koji.py
@@ -131,7 +131,8 @@ class TestKojiBuild:
             f.write("Adeptus Astartes")
 
         # Mock patch file
-        file = os.path.join(tmpdir, "patch")
+        filename = "patch"
+        file = os.path.join(tmpdir, filename)
         with open(file, "w") as f:
             f.write("This is a patch")
         mock_session = mock.Mock()
@@ -149,7 +150,7 @@ class TestKojiBuild:
             "git config",
             "git config",
             "git commit",
-            file.encode(),
+            filename.encode(),
         ]
 
         # Prepare package
@@ -161,7 +162,7 @@ class TestKojiBuild:
         assert output == {
             "build_id": 1000,
             "patch": "This is a patch",
-            "patch_filename": file,
+            "patch_filename": filename,
             "message": "",
         }
 


### PR DESCRIPTION
When testing #276 on staging issue with patch creating was discovered.
This is the fix for "[Errno 2] No such file or directory" happening on
koji builder.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>