### PR TITLE
Fix error when creating update.drop message

### DIFF
--- a/hotness_schema/hotness_schema/messages.py
+++ b/hotness_schema/hotness_schema/messages.py
@@ -93,24 +93,17 @@ class UpdateDrop(message.Message):
             list(str): A list of affected package names or empty list.
         """
         if self.reason == "anitya":
+            # Return name of the project instead of list of Fedora packages
+            # if we don't know how the package is called in Fedora land
             original = self.body["trigger"]["msg"]
+            project_name = ""
+            if "project" in original:
+                project_name = original["project"]["name"]
 
-            packages = []
-            if "packages" in original["message"]:
-                packages = original["message"]["packages"]
-            elif "packages" in original:
-                packages = original["packages"]
+            if "message" in original and "project" in original["message"]:
+                project_name = original["message"]["project"]["name"]
 
-            if packages:
-                return [
-                    set(
-                        [
-                            pkg["package_name"]
-                            for pkg in packages
-                            if pkg["distro"] == "Fedora"
-                        ]
-                    ).pop()
-                ]
+            return [project_name]
 
         if "package_listing" in self.body["trigger"]["msg"]:
             original = self.body["trigger"]["msg"]

--- a/hotness_schema/hotness_schema/tests/test_messages.py
+++ b/hotness_schema/hotness_schema/tests/test_messages.py
@@ -125,41 +125,38 @@ class TestUpdateDrop(unittest.TestCase):
     @mock.patch(
         "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
     )
-    def test_package_reason_anitya_message(self, mock_reason):
+    def test_package_reason_anitya(self, mock_reason):
         """
-        Assert correct package is returned, when reason is anitya and body contains
-        message key.
+        Assert correct package is returned, when reason is anitya.
         """
         mock_reason.return_value = "anitya"
-        message_body = {
-            "trigger": {
-                "msg": {
-                    "message": {
-                        "packages": [{"distro": "Fedora", "package_name": "Dummy"}]
-                    }
-                }
-            }
-        }
+        message_body = {"trigger": {"msg": {"project": {"name": "Dummy"}}}}
         with mock.patch.dict(self.message.body, message_body):
             self.assertEqual(self.message.packages, ["Dummy"])
 
     @mock.patch(
         "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
     )
-    def test_package_reason_anitya_no_packages_in_message(self, mock_reason):
+    def test_package_reason_anitya_no_project(self, mock_reason):
         """
-        Assert correct package is returned, when reason is anitya and body is
-        missing packages key in message key.
+        Assert empty list is returned, when reason is anitya and there is no project
+        in message.
         """
         mock_reason.return_value = "anitya"
-        message_body = {
-            "trigger": {
-                "msg": {
-                    "packages": [{"distro": "Fedora", "package_name": "Dummy"}],
-                    "message": "",
-                }
-            }
-        }
+        message_body = {"trigger": {"msg": {}}}
+        with mock.patch.dict(self.message.body, message_body):
+            self.assertEqual(self.message.packages, [""])
+
+    @mock.patch(
+        "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
+    )
+    def test_package_reason_anitya_message(self, mock_reason):
+        """
+        Assert correct package is returned, when reason is anitya and body contains
+        message key.
+        """
+        mock_reason.return_value = "anitya"
+        message_body = {"trigger": {"msg": {"message": {"project": {"name": "Dummy"}}}}}
         with mock.patch.dict(self.message.body, message_body):
             self.assertEqual(self.message.packages, ["Dummy"])
 

--- a/news/330.bug
+++ b/news/330.bug
@@ -1,0 +1,1 @@
+Error when constructing hotness.update.drop message


### PR DESCRIPTION
When reason for the update.drop message is Anitya, it means that Anitya
doesn't have mapping for the package. Use the project name instead for
creating summary of the package.

Fixes #330

Signed-off-by: Michal Konečný <mkonecny@redhat.com>