### PR TITLE
Add SHA512 values to error message about same sources

### DIFF
--- a/news/286.feature
+++ b/news/286.feature
@@ -1,0 +1,1 @@
+Add SHA512 values to error message about same sources


### PR DESCRIPTION
This will change the checksum from SHA256 to SHA512 and
will also detect identical files between new sources or
old sources.

Closes #286

Signed-off-by: Michal Konečný <mkonecny@redhat.com>