### PR TITLE
Provide podman compatibility

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -14,8 +14,8 @@ RUN dnf install -y krb5-devel
 # Fedora Messaging
 RUN dnf install -y fedora-messaging
 
-# Python packages
-RUN dnf install -y python3-bugzilla python3-dogpile-cache python3-fedora \
+# Python3 and packages
+RUN dnf install -y python3 python3-pip python3-bugzilla python3-dogpile-cache python3-fedora \
     python3-fedmsg python3-koji python3-pycurl python3-requests python3-six \
     python3-black python3-flake8 python3-sphinx
 
@@ -23,7 +23,7 @@ RUN dnf install -y python3-bugzilla python3-dogpile-cache python3-fedora \
 RUN dnf install -y vim-enhanced tox python3-rpdb
 
 # Packages that are required for releasing
-RUN pip install wheel twine towncrier
+RUN pip3 install wheel twine towncrier
 
 COPY . .
 
@@ -32,11 +32,11 @@ RUN cp /app/devel/ansible/roles/hotness-dev/files/config.toml ~
 ENV FEDORA_MESSAGING_CONF=/root/config.toml
 
 # Install local packages in editable mode
-RUN pip install -e /app
-RUN pip install -e /app/hotness_schema
+RUN pip3 install -e /app
+RUN pip3 install -e /app/hotness_schema
 
 # Comment out the line that starts with 'default_ccache_name'
 # for preventing following error: `kinit: Invalid UID in persistent keyring name while getting default ccache`
 RUN sed -i '/^[^#]/ s/\(^.*default_ccache_name.*$\)/#\1/' /etc/krb5.conf
 
-RUN python setup.py develop
+RUN python3 setup.py develop

--- a/docs/dev-guide.rst
+++ b/docs/dev-guide.rst
@@ -84,6 +84,9 @@ Requirements:
 * Docker / Podman (version +3 with podman-docker)
 * Docker Compose
 
+.. warning::
+    If using podman, in ``container-compose.yml`` either the ``depends_on`` block of ``hotness`` service or all the ``healthcheck`` blocks must be commented out. Podman does not support healthchecking yet.
+
 Next, clone the repository and start containers::
 
     $ git clone https://github.com/fedora-infra/the-new-hotness.git

--- a/news/PR340.dev
+++ b/news/PR340.dev
@@ -1,0 +1,1 @@
+Provide podman compatibility


### PR DESCRIPTION
I tested the container environment on RHEL 8 and faced with following errors:

- Somehow getting `pip not found` and `python not found`
- Healthchecks are not recognized by podman, so we need to either comment out `depends_on` block of `hotness` service or all the `healtcheck` blocks.

On this PR, I provide Containerfile compatibility for podman, and updated the docs for letting the contributors know that they should comment `depends_on` or `healtcheck` blocks for using podman.