### PR TITLE
Show stdout + stderr from CalledProcessError

### DIFF
--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -60,6 +60,8 @@ handlers = ["console"]
 # the-new-hotness consumer configuration
 [consumer_config]
 mdapi_url = "https://apps.fedoraproject.org/mdapi"
+# URL to hotness issue tracker that will be shown together with error in bugzilla
+hotness_issue_tracker = "https://github.com/fedora-infra/the-new-hotness/issues"
 # The time in seconds the-new-hotness should wait for a socket to connect
 # before giving up.
 connect_timeout = 15

--- a/hotness/config.py
+++ b/hotness/config.py
@@ -36,6 +36,8 @@ DEFAULTS = dict(
     dist_git_url="https://src.fedoraproject.org",
     # mdapi URL
     mdapi_url="https://apps.fedoraproject.org/mdapi",
+    # hotness issue tracker URL
+    hotness_issue_tracker="https://github.com/fedora-infra/the-new-hotness/issues",
     # Repository id
     repoid="rawhide",
     # Distribution

--- a/hotness/exceptions/builder_exception.py
+++ b/hotness/exceptions/builder_exception.py
@@ -15,6 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+from typing import Optional
+
+
 class BuilderException(Exception):
     """
     Class representing builder exception.
@@ -23,13 +26,25 @@ class BuilderException(Exception):
 
     Attributes:
         message: Error message.
+        output: Partial output from builder, needed for koji build id.
+        std_out: Standard output of command if the exception was triggered by subprocess call.
+        std_err: Error output of command if the exception was triggered by subprocess call.
     """
 
-    def __init__(self, message: str) -> None:
+    def __init__(
+        self,
+        message: str,
+        output: Optional[dict] = {},
+        std_out: Optional[str] = "",
+        std_err: Optional[str] = "",
+    ) -> None:
         """
         Class constructor.
         """
         self.message = message
+        self.output = output
+        self.std_out = std_out
+        self.std_err = std_err
         super(BuilderException, self).__init__(self.message)
 
     def __str__(self) -> str:

--- a/news/333.feature
+++ b/news/333.feature
@@ -1,0 +1,1 @@
+Show stdout + stderr from CalledProcessError

--- a/tests/exceptions/test_builder_exception.py
+++ b/tests/exceptions/test_builder_exception.py
@@ -36,6 +36,25 @@ class TestBuilderExceptionInit:
 
         assert exception.message == "This error is a tech heresy!"
 
+    def test_init_optional_arguments(self):
+        """
+        Assert that exception is created correctly.
+        """
+        exception = BuilderException(
+            "This error is a tech heresy!",
+            output={"build_id": 100},
+            std_out="This is a standard output",
+            std_err="This is an error output",
+        )
+
+        with pytest.raises(Exception):
+            raise exception
+
+        assert exception.message == "This error is a tech heresy!"
+        assert exception.output == {"build_id": 100}
+        assert exception.std_out == "This is a standard output"
+        assert exception.std_err == "This is an error output"
+
 
 class TestBuilderExceptionStr:
     """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,7 @@ full_config = {
         "mdapi_url": "https://apps.fedoraproject.org/mdapi_test",
         "repoid": "",
         "distro": "",
+        "hotness_issue_tracker": "https://github.com/fedora-infra/the-new-hotness/issues",
         "connect_timeout": 30,
         "read_timeout": 30,
         "requests_retries": 1,


### PR DESCRIPTION
This commit adds additional attributes to ResponseFailure class.
* std_out and std_err for BuilderException - this will allow us to print
  stdout and stderr from CalledProcessError to bugzilla issue
* output for BuilderException - this will help us to be able to print
  build link in the future
* traceback - to be able to print traceback in the bugzilla ticket so
  packagers could report the issue

This information are added as comment to bugzilla ticket whenewer the
build fails.

The build failure now also contains a link to the-new-hotness issue
tracker, so it will be easier for packagers to report new issues in the
future.

Closes #333

Signed-off-by: Michal Konečný <mkonecny@redhat.com>