### PR TITLE
Save koji id even if build use case fails

### DIFF
--- a/news/332.bug
+++ b/news/332.bug
@@ -1,0 +1,1 @@
+Save koji task id, even if the build event fails

--- a/tests/test_hotness_consumer.py
+++ b/tests/test_hotness_consumer.py
@@ -497,6 +497,83 @@ class TestHotnessConsumerCall:
             package, "update.bug.file", exp_opts
         )
 
+    def test_call_anitya_update_scratch_build_post_build_failure(self):
+        """
+        Assert that update message is handled correctly when scratch build is started,
+        but there is failure in post build process.
+        """
+        message = create_message("anitya.project.version.update", "fedora_mapping")
+        self.consumer.validator_pagure.validate.return_value = {
+            "monitoring": True,
+            "scratch_build": True,
+        }
+        self.consumer.validator_pdc.validate.return_value = {
+            "retired": False,
+            "count": 1,
+        }
+        self.consumer.validator_mdapi.validate.return_value = {
+            "newer": True,
+            "version": "0.16.0",
+            "release": 1,
+        }
+        builder_exception = BuilderException(
+            "This is heresy!",
+            std_out="This is a standard output",
+            std_err="This is an error output",
+            output={"build_id": 1000},
+        )
+        self.consumer.notifier_bugzilla.notify.return_value = {"bz_id": 100}
+        self.consumer.builder_koji.build.side_effect = builder_exception
+        self.consumer.__call__(message)
+
+        package = Package(name="flatpak", version="1.0.4", distro="Fedora")
+
+        self.consumer.validator_pagure.validate.assert_called_with(package)
+        self.consumer.validator_pdc.validate.assert_called_with(package)
+        self.consumer.validator_mdapi.validate.assert_called_with(package)
+        self.consumer.notifier_bugzilla.notify.assert_has_calls == [
+            mock.call(
+                package,
+                self.consumer.description_template
+                % dict(
+                    latest_upstream=package.version,
+                    repo_name=self.consumer.repoid,
+                    repo_version="0.16.0",
+                    repo_release=1,
+                    url=message.body["project"]["homepage"],
+                    explanation_url=self.consumer.explanation_url,
+                    projectid=message.body["project"]["id"],
+                ),
+                {"bz_short_desc": "flatpak-1.0.4 is available"},
+            ),
+            mock.call(
+                package,
+                (
+                    "Build started but failure happened during post build operations:\n"
+                    "BuilderException: {}\n".format(str(builder_exception)),
+                    "Traceback:\n"
+                    "{}\n".format(traceback.format_tb(builder_exception.__traceback__)),
+                    "StdOut:\n" "{}\n".format(builder_exception.std_out),
+                    "StdErr:\n" "{}\n".format(builder_exception.std_err),
+                ),
+                {"bz_id": 100},
+            ),
+        ]
+        self.consumer.builder_koji.build.assert_called_with(package, {"bz_id": 100})
+
+        exp_opts = {
+            "body": {
+                "trigger": {"msg": message.body, "topic": message.topic},
+                "bug": {"bug_id": 100},
+                "package": package.name,
+            }
+        }
+
+        self.consumer.notifier_fedora_messaging.notify.assert_called_with(
+            package, "update.bug.file", exp_opts
+        )
+        self.consumer.database_cache.insert.assert_called_with("1000", "100")
+
     def test_call_anitya_update_no_monitoring(self):
         """
         Assert that update message is handled correctly when monitoring is not set.


### PR DESCRIPTION
Currently the-new-hotness didn't saved the koji build id when any
failure happened during the build use case. This caused that when the
build fedora message arrived it was not recognized by the-new-hotness.

This commit is saving the koji build id to cache even when there is
failure during the build use case, but the build successfully started.

Fixes #332

Signed-off-by: Michal Konečný <mkonecny@redhat.com>