### PR TITLE
Fix tox in container

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -20,7 +20,7 @@ RUN dnf install -y python3 python3-pip python3-bugzilla python3-dogpile-cache py
     python3-black python3-flake8 python3-sphinx
 
 # Development tools (for doing stuff inside of the container)
-RUN dnf install -y vim-enhanced tox python3-rpdb
+RUN dnf install -y vim-enhanced tox python3-rpdb gcc
 
 # Packages that are required for releasing
 RUN pip3 install wheel twine towncrier


### PR DESCRIPTION
The tox wasn't able to install dependencies, because of missing gcc.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>