### PR TITLE
Unify exceptions

### DIFF
--- a/hotness/builders/koji.py
+++ b/hotness/builders/koji.py
@@ -186,7 +186,7 @@ class Koji(Builder):
                 if exc.stderr:
                     std_err = exc.stderr.decode()
                 raise BuilderException(
-                    str(exc), output=output, std_out=std_out, std_err=std_err
+                    str(exc), value=output, std_out=std_out, std_err=std_err
                 )
 
             srpm = os.path.join(tmp, cmd_output.decode("utf-8").strip().split()[-1])
@@ -224,7 +224,7 @@ class Koji(Builder):
                 if exc.stderr:
                     std_err = exc.stderr.decode()
                 raise BuilderException(
-                    str(exc), output=output, std_out=std_out, std_err=std_err
+                    str(exc), value=output, std_out=std_out, std_err=std_err
                 )
 
             output["patch_filename"] = filename

--- a/hotness/exceptions/__init__.py
+++ b/hotness/exceptions/__init__.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+from .base_exception import BaseHotnessException  # noqa: F401
 from .builder_exception import BuilderException  # noqa: F401
 from .download_exception import DownloadException  # noqa: F401
 from .http_exception import HTTPException  # noqa: F401

--- a/hotness/exceptions/base_exception.py
+++ b/hotness/exceptions/base_exception.py
@@ -15,22 +15,34 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-from . import BaseHotnessException
+from typing import Any, Optional
 
 
-class DownloadException(BaseHotnessException):
+class BaseHotnessException(Exception):
     """
-    Class representing download exception.
-    This exception is raised by builder
-    when downloading of sources fails.
+    Class representing base exception in the-new-hotness.
+    This exception should be inherited by every other exception
+    and defines common methods and attributes expected by `ResponseFailure` object.
 
     Attributes:
         message: Error message.
+        value: Partial output from object that raised the exception, default: None.
     """
 
-    def __init__(self, message: str):
+    def __init__(
+        self,
+        message: str,
+        value: Optional[Any] = None,
+    ) -> None:
         """
         Class constructor.
         """
         self.message = message
-        super(DownloadException, self).__init__(self.message)
+        self.value = value
+        super(BaseHotnessException, self).__init__(self.message)
+
+    def __str__(self) -> str:
+        """
+        String representation of error.
+        """
+        return self.message

--- a/hotness/exceptions/builder_exception.py
+++ b/hotness/exceptions/builder_exception.py
@@ -17,8 +17,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 from typing import Optional
 
+from . import BaseHotnessException
 
-class BuilderException(Exception):
+
+class BuilderException(BaseHotnessException):
     """
     Class representing builder exception.
     This exception is raised by builder
@@ -26,7 +28,7 @@ class BuilderException(Exception):
 
     Attributes:
         message: Error message.
-        output: Partial output from builder, needed for koji build id.
+        value: Partial output from builder, needed for koji build id.
         std_out: Standard output of command if the exception was triggered by subprocess call.
         std_err: Error output of command if the exception was triggered by subprocess call.
     """
@@ -34,7 +36,7 @@ class BuilderException(Exception):
     def __init__(
         self,
         message: str,
-        output: Optional[dict] = {},
+        value: Optional[dict] = {},
         std_out: Optional[str] = "",
         std_err: Optional[str] = "",
     ) -> None:
@@ -42,13 +44,25 @@ class BuilderException(Exception):
         Class constructor.
         """
         self.message = message
-        self.output = output
+        self.value = value
         self.std_out = std_out
         self.std_err = std_err
-        super(BuilderException, self).__init__(self.message)
+        super(BuilderException, self).__init__(self.message, self.value)
 
     def __str__(self) -> str:
         """
         String representation of error.
         """
-        return self.message
+        message = ""
+        if "build_id" in self.value:
+            message = (
+                "Build started, but failure happened "
+                "during post build operations:\n{}\n"
+            ).format(self.message)
+        else:
+            message = "Build failed:\n{}\n".format(self.message)
+        if self.std_out:
+            message = message + "\nStdOut:\n{}\n".format(self.std_out)
+        if self.std_err:
+            message = message + "\nStdErr:\n{}\n".format(self.std_err)
+        return message

--- a/hotness/exceptions/http_exception.py
+++ b/hotness/exceptions/http_exception.py
@@ -15,7 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class HTTPException(Exception):
+from . import BaseHotnessException
+
+
+class HTTPException(BaseHotnessException):
     """
     Class representing HTTP exception. This exception should be returned by any wrapper receiving
     HTTP response when the error code is not 200.

--- a/hotness/exceptions/notifier_exception.py
+++ b/hotness/exceptions/notifier_exception.py
@@ -15,7 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class NotifierException(Exception):
+from . import BaseHotnessException
+
+
+class NotifierException(BaseHotnessException):
     """
     Class representing notifier exception.
     This exception is raised by notifier
@@ -31,9 +34,3 @@ class NotifierException(Exception):
         """
         self.message = message
         super(NotifierException, self).__init__(self.message)
-
-    def __str__(self) -> str:
-        """
-        String representation of error.
-        """
-        return self.message

--- a/hotness/exceptions/patcher_exception.py
+++ b/hotness/exceptions/patcher_exception.py
@@ -15,7 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-class PatcherException(Exception):
+from . import BaseHotnessException
+
+
+class PatcherException(BaseHotnessException):
     """
     Class representing patcher exception.
     This exception is raised by patcher
@@ -31,9 +34,3 @@ class PatcherException(Exception):
         """
         self.message = message
         super(PatcherException, self).__init__(self.message)
-
-    def __str__(self) -> str:
-        """
-        String representation of error.
-        """
-        return self.message

--- a/hotness/hotness_consumer.py
+++ b/hotness/hotness_consumer.py
@@ -589,20 +589,11 @@ class HotnessConsumer(object):
         build_koji_use_case = PackageScratchBuildUseCase(self.builder_koji)
         response = build_koji_use_case.build(build_request)
         if not response:
-            if "build_id" in response.output:
-                build_id = response.output["build_id"]
-                message = (
-                    "Build started but failure happened"
-                    "during post build operations:\n{}\n"
-                ).format(response.value["message"])
-            else:
-                message = "Build failed:\n{}\n".format(response.value["message"])
+            message = response.message
             if response.traceback:
-                message = message + "Traceback:\n{}\n".format(response.traceback)
-            if response.stdout:
-                message = message + "StdOut:\n{}\n".format(response.stdout)
-            if response.stderr:
-                message = message + "StdErr:\n{}\n".format(response.stderr)
+                message = message + "\nTraceback:\n{}\n".format(
+                    "".join(response.traceback)
+                )
             message = message + (
                 "If you think this issue is caused by some bug in the-new-hotness, "
                 "please report it on the-new-hotness issue tracker: "
@@ -617,8 +608,8 @@ class HotnessConsumer(object):
             notifier_bugzilla_use_case.notify(notify_request)
 
             # Insert the build_id to cache if available
-            if "build_id" in response.output:
-                build_id = response.output["build_id"]
+            if response.use_case_value and "build_id" in response.use_case_value:
+                build_id = response.use_case_value["build_id"]
                 insert_data_request = InsertDataRequest(
                     key=str(build_id), value=str(bz_id)
                 )

--- a/news/345.bug
+++ b/news/345.bug
@@ -1,0 +1,1 @@
+Fix the format error when scratch build fails

--- a/news/353.dev
+++ b/news/353.dev
@@ -1,0 +1,1 @@
+Unify exceptions

--- a/tests/builders/test_koji.py
+++ b/tests/builders/test_koji.py
@@ -630,7 +630,7 @@ class TestKojiBuild:
         assert (
             exc.value.message == "Command 'git clone' returned non-zero exit status 1."
         )
-        assert exc.value.output == {}
+        assert exc.value.value == {}
         assert exc.value.std_out == "Some output"
         assert exc.value.std_err == "Failed miserably"
 
@@ -662,7 +662,7 @@ class TestKojiBuild:
             exc.value.message
             == "Command 'rpmdev-bumpspec' returned non-zero exit status 1."
         )
-        assert exc.value.output == {}
+        assert exc.value.value == {}
         assert exc.value.std_out == "Some output"
         assert exc.value.std_err == "Failed miserably"
 
@@ -700,7 +700,7 @@ class TestKojiBuild:
             exc.value.message
             == "Command 'rpmdevbuild' returned non-zero exit status 1."
         )
-        assert exc.value.output["message"] != ""
+        assert exc.value.value["message"] != ""
         assert exc.value.std_out == "Some output"
         assert exc.value.std_err == "Failed miserably"
 
@@ -748,6 +748,6 @@ class TestKojiBuild:
         assert (
             exc.value.message == "Command 'git commit' returned non-zero exit status 1."
         )
-        assert exc.value.output["build_id"] == 1000
+        assert exc.value.value["build_id"] == 1000
         assert exc.value.std_out == "Some output"
         assert exc.value.std_err == "Failed miserably"

--- a/tests/exceptions/test_base_exception.py
+++ b/tests/exceptions/test_base_exception.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+import pytest
+
+from hotness.exceptions import BaseHotnessException
+
+
+class TestBaseExceptionInit:
+    """
+    Test class for `hotness.exceptions.BaseHotnessException.__init__` method.
+    """
+
+    def test_init(self):
+        """
+        Assert that exception is created correctly.
+        """
+        exception = BaseHotnessException("This error is a tech heresy!")
+
+        with pytest.raises(Exception):
+            raise exception
+
+        assert exception.message == "This error is a tech heresy!"
+
+    def test_init_optional_arguments(self):
+        """
+        Assert that exception is created correctly.
+        """
+        exception = BaseHotnessException(
+            "This error is a tech heresy!",
+            value={"build_id": 100},
+        )
+
+        with pytest.raises(Exception):
+            raise exception
+
+        assert exception.message == "This error is a tech heresy!"
+        assert exception.value == {"build_id": 100}
+
+
+class TestBaseExceptionStr:
+    """
+    Test class for `hotness.exceptions.BaseHotnessException.__str__` method.
+    """
+
+    def test_str(self):
+        """
+        Assert that the string representation of exception is correct.
+        """
+        exception = BaseHotnessException("This error is a tech heresy!")
+
+        assert str(exception) == "This error is a tech heresy!"

--- a/tests/exceptions/test_builder_exception.py
+++ b/tests/exceptions/test_builder_exception.py
@@ -42,7 +42,7 @@ class TestBuilderExceptionInit:
         """
         exception = BuilderException(
             "This error is a tech heresy!",
-            output={"build_id": 100},
+            value={"build_id": 100},
             std_out="This is a standard output",
             std_err="This is an error output",
         )
@@ -51,7 +51,7 @@ class TestBuilderExceptionInit:
             raise exception
 
         assert exception.message == "This error is a tech heresy!"
-        assert exception.output == {"build_id": 100}
+        assert exception.value == {"build_id": 100}
         assert exception.std_out == "This is a standard output"
         assert exception.std_err == "This is an error output"
 
@@ -67,4 +67,38 @@ class TestBuilderExceptionStr:
         """
         exception = BuilderException("This error is a tech heresy!")
 
-        assert str(exception) == "This error is a tech heresy!"
+        assert str(exception) == ("Build failed:\n" "This error is a tech heresy!\n")
+
+    def test_str_build_id(self):
+        """
+        Assert that the string representation of exception is correct
+        when build id is available.
+        """
+        exception = BuilderException(
+            "This error is a tech heresy!", value={"build_id": 100}
+        )
+
+        assert str(exception) == (
+            "Build started, but failure happened during post build operations:\n"
+            "This error is a tech heresy!\n"
+        )
+
+    def test_str_std_err_out(self):
+        """
+        Assert that the string representation of exception is correct
+        when stderr and stdout are available.
+        """
+        exception = BuilderException(
+            "This error is a tech heresy!",
+            std_err="This blasphemy should never happen!",
+            std_out="Praise Slaanesh!",
+        )
+
+        assert str(exception) == (
+            "Build failed:\n"
+            "This error is a tech heresy!\n\n"
+            "StdOut:\n"
+            "Praise Slaanesh!\n\n"
+            "StdErr:\n"
+            "This blasphemy should never happen!\n"
+        )

--- a/tests/exceptions/test_download_exception.py
+++ b/tests/exceptions/test_download_exception.py
@@ -35,17 +35,3 @@ class TestDownloadExceptionInit:
             raise exception
 
         assert exception.message == "This error is a tech heresy!"
-
-
-class TestDownloadExceptionStr:
-    """
-    Test class for `hotness.exceptions.DownloadException.__str__` method.
-    """
-
-    def test_str(self):
-        """
-        Assert that the string representation of exception is correct.
-        """
-        exception = DownloadException("This error is a tech heresy!")
-
-        assert str(exception) == "This error is a tech heresy!"

--- a/tests/exceptions/test_notifier_exception.py
+++ b/tests/exceptions/test_notifier_exception.py
@@ -35,17 +35,3 @@ class TestNotifierExceptionInit:
             raise exception
 
         assert exception.message == "This error is a tech heresy!"
-
-
-class TestNotifierExceptionStr:
-    """
-    Test class for `hotness.exceptions.NotifierException.__str__` method.
-    """
-
-    def test_str(self):
-        """
-        Assert that the string representation of exception is correct.
-        """
-        exception = NotifierException("This error is a tech heresy!")
-
-        assert str(exception) == "This error is a tech heresy!"

--- a/tests/exceptions/test_patcher_exception.py
+++ b/tests/exceptions/test_patcher_exception.py
@@ -35,17 +35,3 @@ class TestPatcherExceptionInit:
             raise exception
 
         assert exception.message == "This error is a tech heresy!"
-
-
-class TestPatcherExceptionStr:
-    """
-    Test class for `hotness.exceptions.PatcherException.__str__` method.
-    """
-
-    def test_str(self):
-        """
-        Assert that the string representation of exception is correct.
-        """
-        exception = PatcherException("This error is a tech heresy!")
-
-        assert str(exception) == "This error is a tech heresy!"

--- a/tests/responses/test_response_failure.py
+++ b/tests/responses/test_response_failure.py
@@ -39,11 +39,10 @@ class TestResponseFailureInit:
         assert response.value == {
             "type": ResponseFailure.VALIDATOR_ERROR,
             "message": "This is heresy!",
+            "use_case_value": None,
         }
         assert response.traceback == []
-        assert response.output == {}
-        assert response.stderr == ""
-        assert response.stdout == ""
+        assert response.use_case_value is None
 
 
 class TestResponseFailureBool:
@@ -79,6 +78,7 @@ class TestResponseFailureValidatorError:
         assert response.value == {
             "type": ResponseFailure.VALIDATOR_ERROR,
             "message": "Exception: This is validator heresy!",
+            "use_case_value": None,
         }
 
 
@@ -99,6 +99,7 @@ class TestResponseFailureBuilderError:
         assert response.value == {
             "type": ResponseFailure.BUILDER_ERROR,
             "message": "Exception: This is builder heresy!",
+            "use_case_value": None,
         }
 
     def test_buider_exception(self):
@@ -107,7 +108,7 @@ class TestResponseFailureBuilderError:
         """
         builder_exception = BuilderException(
             "This is builder heresy!",
-            output={"build_id": 100},
+            value={"build_id": 100},
             std_out="This is a standard output.",
             std_err="This is an error output.",
         )
@@ -117,14 +118,20 @@ class TestResponseFailureBuilderError:
         assert response.type == ResponseFailure.BUILDER_ERROR
         assert response.value == {
             "type": ResponseFailure.BUILDER_ERROR,
-            "message": "BuilderException: This is builder heresy!",
+            "message": (
+                "BuilderException: Build started, but failure happened "
+                "during post build operations:\nThis is builder heresy!\n\n"
+                "StdOut:\n"
+                "This is a standard output.\n\n"
+                "StdErr:\n"
+                "This is an error output.\n"
+            ),
+            "use_case_value": {"build_id": 100},
         }
         assert response.traceback == traceback.format_tb(
             builder_exception.__traceback__
         )
-        assert response.output == {"build_id": 100}
-        assert response.stdout == "This is a standard output."
-        assert response.stderr == "This is an error output."
+        assert response.use_case_value == {"build_id": 100}
 
 
 class TestResponseFailureDatabaseError:
@@ -144,6 +151,7 @@ class TestResponseFailureDatabaseError:
         assert response.value == {
             "type": ResponseFailure.DATABASE_ERROR,
             "message": "Exception: This is database heresy!",
+            "use_case_value": None,
         }
 
 
@@ -164,6 +172,7 @@ class TestResponseFailureNotifierError:
         assert response.value == {
             "type": ResponseFailure.NOTIFIER_ERROR,
             "message": "Exception: This is notifier heresy!",
+            "use_case_value": None,
         }
 
 
@@ -184,6 +193,7 @@ class TestResponseFailurePatcherError:
         assert response.value == {
             "type": ResponseFailure.PATCHER_ERROR,
             "message": "Exception: This is patcher heresy!",
+            "use_case_value": None,
         }
 
 
@@ -204,4 +214,5 @@ class TestResponseFailureInvalidRequestError:
         assert response.value == {
             "type": ResponseFailure.INVALID_REQUEST_ERROR,
             "message": "[{'parameter': 'param', 'error': 'You shall not pass!'}]",
+            "use_case_value": None,
         }

--- a/tests/use_cases/test_insert_data_use_case.py
+++ b/tests/use_cases/test_insert_data_use_case.py
@@ -91,6 +91,7 @@ class TestInsertDataUseCaseInsert:
         assert result.value == {
             "type": responses.ResponseFailure.INVALID_REQUEST_ERROR,
             "message": str(errors),
+            "use_case_value": None,
         }
 
     def test_insert_failure(self):
@@ -118,4 +119,5 @@ class TestInsertDataUseCaseInsert:
         assert result.value == {
             "type": responses.ResponseFailure.DATABASE_ERROR,
             "message": "Exception: This is heresy!",
+            "use_case_value": None,
         }

--- a/tests/use_cases/test_notify_user_use_case.py
+++ b/tests/use_cases/test_notify_user_use_case.py
@@ -93,6 +93,7 @@ class TestNotifyUserUseCaseNotify:
         assert result.value == {
             "type": responses.ResponseFailure.INVALID_REQUEST_ERROR,
             "message": str(errors),
+            "use_case_value": None,
         }
 
     def test_notify_failure(self):
@@ -122,4 +123,5 @@ class TestNotifyUserUseCaseNotify:
         assert result.value == {
             "type": responses.ResponseFailure.NOTIFIER_ERROR,
             "message": "Exception: This is heresy!",
+            "use_case_value": None,
         }

--- a/tests/use_cases/test_package_check_use_case.py
+++ b/tests/use_cases/test_package_check_use_case.py
@@ -109,6 +109,7 @@ class TestPackageCheckUseCaseValidate:
         assert result.value == {
             "type": responses.ResponseFailure.INVALID_REQUEST_ERROR,
             "message": str(errors),
+            "use_case_value": None,
         }
 
     def test_validate_failure(self):
@@ -133,4 +134,5 @@ class TestPackageCheckUseCaseValidate:
         assert result.value == {
             "type": responses.ResponseFailure.VALIDATOR_ERROR,
             "message": "Exception: This is heresy!",
+            "use_case_value": None,
         }

--- a/tests/use_cases/test_package_scratch_build_use_case.py
+++ b/tests/use_cases/test_package_scratch_build_use_case.py
@@ -93,6 +93,7 @@ class TestPackageScratchBuildUseCaseBuild:
         assert result.value == {
             "type": responses.ResponseFailure.INVALID_REQUEST_ERROR,
             "message": str(errors),
+            "use_case_value": None,
         }
 
     def test_build_failure(self):
@@ -119,4 +120,5 @@ class TestPackageScratchBuildUseCaseBuild:
         assert result.value == {
             "type": responses.ResponseFailure.BUILDER_ERROR,
             "message": "Exception: This is heresy!",
+            "use_case_value": None,
         }

--- a/tests/use_cases/test_retrieve_data_use_case.py
+++ b/tests/use_cases/test_retrieve_data_use_case.py
@@ -90,6 +90,7 @@ class TestRetrieveDataUseCaseRetrieve:
         assert result.value == {
             "type": responses.ResponseFailure.INVALID_REQUEST_ERROR,
             "message": str(errors),
+            "use_case_value": None,
         }
 
     def test_retrieve_failure(self):
@@ -115,4 +116,5 @@ class TestRetrieveDataUseCaseRetrieve:
         assert result.value == {
             "type": responses.ResponseFailure.DATABASE_ERROR,
             "message": "Exception: This is heresy!",
+            "use_case_value": None,
         }

--- a/tests/use_cases/test_submit_patch_use_case.py
+++ b/tests/use_cases/test_submit_patch_use_case.py
@@ -94,6 +94,7 @@ class TestSubmitPatchUseCaseSubmitPatch:
         assert result.value == {
             "type": responses.ResponseFailure.INVALID_REQUEST_ERROR,
             "message": str(errors),
+            "use_case_value": None,
         }
 
     def test_build_failure(self):
@@ -121,4 +122,5 @@ class TestSubmitPatchUseCaseSubmitPatch:
         assert result.value == {
             "type": responses.ResponseFailure.PATCHER_ERROR,
             "message": "Exception: This is heresy!",
+            "use_case_value": None,
         }


### PR DESCRIPTION
Create a BaseHotnessExceptions that will define the default values for
properties and methods expected by ResponseFailure class. This will help
with inconsistency when working with exceptions.

* Adds new BaseHotnessException
* Moves the message construction to BuilderException
* Adds inheritance of the BaseHotnessException to other exceptions
* Removes unecessary methods from ResponseFailure class
* Add new method for value in ResponseFailure class, this will return
  the value in exception
* Removes message construction from HotnessConsumer, to prevent crashes
  when DownloadException is returned instead of BuilderException

Fixes #345
Fixes #353

Signed-off-by: Michal Konečný <mkonecny@redhat.com>