### PR TITLE
Drop support for python 3.6

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,24 +1,4 @@
 - job:
-    name: tox-python36
-    description: |
-      Run unit tests for a Python project under cPython version 3.6.
-
-      Uses tox with the ``py36`` environment.
-
-      Ensures that the python36 interpreter is installed.
-
-    parent: tox
-    run: ci/test-tox.yaml
-    vars:
-      tox_env: py36
-      dependencies:
-        - python36
-    nodeset:
-      nodes:
-        name: test-node
-        label: pod-python-f33
-
-- job:
     name: tox-python37
     description: |
       Run unit tests for a Python project under cPython version 3.7.
@@ -66,10 +46,6 @@
               dependencies:
                 - gcc
         - tox-format:
-            vars:
-              dependencies:
-                - gcc
-        - tox-python36:
             vars:
               dependencies:
                 - gcc

--- a/news/391.bug
+++ b/news/391.bug
@@ -1,0 +1,1 @@
+Drop Python 3.6 support

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,5 @@ setup(
     tests_require=get_requirements("dev-requirements.txt"),
     packages=find_packages(exclude=("hotness.tests", "hotness.tests.*")),
     test_suite="hotness.tests",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,lint,format,diff-cover,docs,bandit
+envlist = py37,py38,py39,lint,format,diff-cover,docs,bandit
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.6 is now EOL. Drop it from the-new-hotness.

Closes #391

Signed-off-by: Michal Konečný <mkonecny@redhat.com>