### PR TITLE
Add krb5-devel dependency to CI jobs defined in Anitya

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -47,11 +47,11 @@
         - tox-lint:
             vars:
               dependencies:
-                - gcc
+                - krb5-devel
         - tox-format:
             vars:
               dependencies:
-                - gcc
+                - krb5-devel
         - tox-python37:
             vars:
               dependencies:
@@ -59,11 +59,11 @@
         - tox-python38:
             vars:
               dependencies:
-                - gcc
+                - krb5-devel
         - tox-python39:
             vars:
               dependencies:
-                - gcc
+                - krb5-devel
         - simple-tox-docs:
             vars:
               dependencies:
@@ -71,8 +71,8 @@
         - tox-bandit:
             vars:
               dependencies:
-                - gcc
+                - krb5-devel
         - tox-diff-cover:
             vars:
               dependencies:
-                - gcc
+                - krb5-devel


### PR DESCRIPTION
Anitya jobs were migrated from pod-python-f35 label to cloud-fedora-35 and we
need to adjust to this change.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>