### PR TITLE
Prepare for change in Bugzilla API

### DIFF
--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -78,10 +78,8 @@ requests_retries = 3
 enabled = true
 # User that is used to report the issue in bugzilla
 reporter = "Upstream Release Monitoring"
-# When authenticated by user and password, uncomment the following lines
-# and comment out api_key
-#user = None
-#password = None
+# E-mail of the reporter bugzilla account
+reporter_email = "upstream-release-monitoring@fedoraproject.org"
 # Use bugzilla API key for communication with bugzilla
 api_key = ""
 # URL of the bugzilla instance

--- a/devel/ansible/roles/hotness-dev/files/config.toml
+++ b/devel/ansible/roles/hotness-dev/files/config.toml
@@ -74,10 +74,8 @@ legacy_messaging = false
 
 [consumer_config.bugzilla]
 enabled = true
-#user = None
-#password = None
 api_key = ""
-url = "https://partner-bugzilla.redhat.com"
+url = "https://bugzilla.stage.redhat.com"
 product = "Fedora"
 version = "rawhide"
 keywords = "FutureFeature,Triaged"

--- a/hotness/config.py
+++ b/hotness/config.py
@@ -55,8 +55,6 @@ DEFAULTS = dict(
     bugzilla=dict(
         enabled=True,
         url="https://partner-bugzilla.redhat.com",
-        user=None,
-        password=None,
         api_key="",
         product="Fedora",
         version="rawhide",
@@ -64,6 +62,7 @@ DEFAULTS = dict(
         bug_status="NEW",
         explanation_url="https://fedoraproject.org/wiki/upstream_release_monitoring",
         reporter="Upstream Release Monitoring",
+        reporter_email="upstream-release-monitoring@fedoraproject.org",
         short_desc_template="%(name)s-%(latest_upstream)s is available",
         description_template="""
 Latest upstream release: %(latest_upstream)s
@@ -161,11 +160,7 @@ def load(config_dict: dict) -> dict:
     _log.info("Loading the-new-hotness configuration")
     config = _load_dict(consumer_config, config)
 
-    if (
-        config["bugzilla"]["user"] == DEFAULTS["bugzilla"]["user"]
-        and config["bugzilla"]["password"] == DEFAULTS["bugzilla"]["password"]
-        and config["bugzilla"]["api_key"] == DEFAULTS["bugzilla"]["api_key"]
-    ):
+    if config["bugzilla"]["api_key"] == DEFAULTS["bugzilla"]["api_key"]:
         _log.warning(
             "No authentication method configured for bugzilla."
             "The-new-hotness will be unable to do any change in bugzilla."

--- a/hotness/hotness_consumer.py
+++ b/hotness/hotness_consumer.py
@@ -138,8 +138,7 @@ class HotnessConsumer(object):
         self.notifier_bugzilla = bz_notifier(
             server_url=config["bugzilla"]["url"],
             reporter=config["bugzilla"]["reporter"],
-            username=config["bugzilla"]["user"],
-            password=config["bugzilla"]["password"],
+            email=config["bugzilla"]["reporter_email"],
             api_key=config["bugzilla"]["api_key"],
             product=config["bugzilla"]["product"],
             keywords=config["bugzilla"]["keywords"],
@@ -149,8 +148,6 @@ class HotnessConsumer(object):
         self.notifier_fedora_messaging = FedoraMessaging(prefix=PREFIX)
         self.patcher_bugzilla = bz_patcher(
             server_url=config["bugzilla"]["url"],
-            username=config["bugzilla"]["user"],
-            password=config["bugzilla"]["password"],
             api_key=config["bugzilla"]["api_key"],
         )
         self.validator_mdapi = MDApi(

--- a/hotness/notifiers/bugzilla.py
+++ b/hotness/notifiers/bugzilla.py
@@ -73,8 +73,7 @@ class Bugzilla(Notifier):
         self,
         server_url: str,
         reporter: str,
-        username: str,
-        password: str,
+        email: str,
         api_key: str,
         product: str,
         keywords: str,
@@ -85,15 +84,12 @@ class Bugzilla(Notifier):
         Class constructor.
 
         It initializes bugzilla session using the provided credentials.
-        If the `api_key` is not provided, it will try to establish a session
-        using `username` and `password`. If none of these authentication
-        methods is provided it raises an `NotifierException`.
+        If the `api_key` is not provided it raises an `NotifierException`.
 
         Params:
             server_url: URL of the bugzilla server
-            reporter: Reporter e-mail to use
-            username: Username to use for authentication
-            password: Password to use for authentication
+            reporter: User that is reporting the issues
+            email: E-mail of the reporter user
             api_key: API key to use for authentication
             product: Product to assign the ticket to
             keywords: Keywords for the new ticket
@@ -108,25 +104,16 @@ class Bugzilla(Notifier):
             self.bugzilla = bugzilla.Bugzilla(
                 url=server_url, api_key=api_key, cookiefile=None, tokenfile=None
             )
-        elif username and password:
-            self.bugzilla = bugzilla.Bugzilla(
-                url=server_url,
-                user=username,
-                password=password,
-                cookiefile=None,
-                tokenfile=None,
-            )
         else:
             raise NotifierException(
-                "Authentication info not provided! Provide either 'username' and 'password' "
-                "or API key."
+                "Authentication info not provided! Provide API key."
             )
         self.bugzilla.bug_autorefresh = True
 
         self.reporter = reporter
 
         self.base_query["product"] = product
-        self.base_query["email1"] = username
+        self.base_query["email1"] = email
 
         self.new_bug["product"] = product
         if keywords:

--- a/hotness/patchers/bugzilla.py
+++ b/hotness/patchers/bugzilla.py
@@ -41,21 +41,16 @@ class Bugzilla(Patcher):
     def __init__(
         self,
         server_url: str,
-        username: str,
-        password: str,
         api_key: str,
     ) -> None:
         """
         Class constructor.
 
         It initializes bugzilla session using the provided credentials.
-        If the `api_key` is not provided, it will try to establish a session
-        using `username` and `password`.
+        If the `api_key` is not provided it raises an `PatcherException`.
 
         Params:
             server_url: URL of the bugzilla server
-            username: Username to use for authentication
-            password: Password to use for authentication
             api_key: API key to use for authentication
 
         Raises:
@@ -66,19 +61,8 @@ class Bugzilla(Patcher):
             self.bugzilla = bugzilla.Bugzilla(
                 url=server_url, api_key=api_key, cookiefile=None, tokenfile=None
             )
-        elif username and password:
-            self.bugzilla = bugzilla.Bugzilla(
-                url=server_url,
-                user=username,
-                password=password,
-                cookiefile=None,
-                tokenfile=None,
-            )
         else:
-            raise PatcherException(
-                "Authentication info not provided! Provide either 'username' and 'password' "
-                "or API key."
-            )
+            raise PatcherException("Authentication info not provided! Provide API key.")
         self.bugzilla.bug_autorefresh = True
 
     def submit_patch(self, package: Package, patch: str, opts: dict) -> dict:

--- a/news/401.dev
+++ b/news/401.dev
@@ -1,0 +1,1 @@
+Prepare for change in Bugzilla API

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 anitya-schema>=1.1.0, <3.0.0
 fedora-messaging>=2.0.1, <4.0.0
 koji>=1.21.0, <2.0.0
-python-bugzilla>=2.3.0, <4.0.0
+python-bugzilla>=3.2.0, <4.0.0
 requests>=2.22.0, <3.0.0

--- a/tests/notifiers/test_bugzilla.py
+++ b/tests/notifiers/test_bugzilla.py
@@ -34,9 +34,8 @@ class TestBugzillaInit:
         Assert that Bugzilla notifier object is initialized correctly.
         """
         server_url = "https://example.com/"
-        reporter = "cain@inquisition.w40k"
-        username = "Fabius@Bile.w40k"
-        password = "UltraSuperHyperPassword"
+        reporter = "Fabius Bile"
+        reporter_email = "Fabius@Bile.w40k"
         api_key = "some API key"
         product = "Fedora"
         keywords = "Tzeentch, Chaos"
@@ -48,8 +47,7 @@ class TestBugzillaInit:
         notifier = Bugzilla(
             server_url,
             reporter,
-            username,
-            password,
+            reporter_email,
             api_key,
             product,
             keywords,
@@ -67,63 +65,7 @@ class TestBugzillaInit:
             "query_format": "advanced",
             "emailreporter1": "1",
             "emailtype1": "exact",
-            "email1": username,
-            "product": product,
-        }
-        assert notifier.new_bug == {
-            "op_sys": "Unspecified",
-            "platform": "Unspecified",
-            "bug_severity": "unspecified",
-            "product": product,
-            "keywords": keywords,
-            "version": version,
-            "status": status,
-        }
-
-    @mock.patch("hotness.notifiers.bugzilla.bugzilla")
-    def test_init_no_api_key(self, mock_bugzilla):
-        """
-        Assert that Bugzilla notifier object is initialized correctly when api_key is not provided.
-        """
-        server_url = "https://example.com/"
-        reporter = "cain@inquisition.w40k"
-        username = "Fabius@Bile.w40k"
-        password = "UltraSuperHyperPassword"
-        api_key = ""
-        product = "Fedora"
-        keywords = "Tzeentch, Chaos"
-        version = "1.0"
-        status = "NEW"
-        bugzilla_session = mock.Mock()
-        mock_bugzilla.Bugzilla.return_value = bugzilla_session
-
-        notifier = Bugzilla(
-            server_url,
-            reporter,
-            username,
-            password,
-            api_key,
-            product,
-            keywords,
-            version,
-            status,
-        )
-
-        mock_bugzilla.Bugzilla.assert_called_with(
-            url=server_url,
-            user=username,
-            password=password,
-            cookiefile=None,
-            tokenfile=None,
-        )
-
-        assert notifier.reporter == reporter
-        assert notifier.bugzilla == bugzilla_session
-        assert notifier.base_query == {
-            "query_format": "advanced",
-            "emailreporter1": "1",
-            "emailtype1": "exact",
-            "email1": username,
+            "email1": reporter_email,
             "product": product,
         }
         assert notifier.new_bug == {
@@ -142,9 +84,8 @@ class TestBugzillaInit:
         if authentication info is not provided.
         """
         server_url = "https://example.com/"
-        reporter = "cain@inquisition.w40k"
-        username = ""
-        password = ""
+        reporter = "Fabius Bile"
+        reporter_email = "Fabius@Bile.w40k"
         api_key = ""
         product = "Fedora"
         keywords = "Tzeentch, Chaos"
@@ -155,8 +96,7 @@ class TestBugzillaInit:
             Bugzilla(
                 server_url,
                 reporter,
-                username,
-                password,
+                reporter_email,
                 api_key,
                 product,
                 keywords,
@@ -165,8 +105,7 @@ class TestBugzillaInit:
             )
 
         assert exc.value.message == (
-            "Authentication info not provided! Provide either 'username' and 'password' "
-            "or API key."
+            "Authentication info not provided! Provide API key."
         )
 
 
@@ -181,9 +120,8 @@ class TestBugzillaNotify:
         Create notifier instance for tests.
         """
         server_url = "https://example.com/"
-        reporter = "cain@inquisition.w40k"
-        username = "Fabius@Bile.w40k"
-        password = "UltraSuperHyperPassword"
+        reporter = "Fabius Bile"
+        reporter_email = "Fabius@Bile.w40k"
         api_key = "some API key"
         product = "Fedora"
         keywords = ["Tzeentch", "Chaos"]
@@ -195,8 +133,7 @@ class TestBugzillaNotify:
         self.notifier = Bugzilla(
             server_url,
             reporter,
-            username,
-            password,
+            reporter_email,
             api_key,
             product,
             keywords,

--- a/tests/patchers/test_bugzilla.py
+++ b/tests/patchers/test_bugzilla.py
@@ -36,46 +36,16 @@ class TestBugzillaInit:
         Assert that Bugzilla patcher object is initialized correctly.
         """
         server_url = "https://example.com/"
-        username = "Fabius@Bile.w40k"
-        password = "UltraSuperHyperPassword"
         api_key = "some API key"
         bugzilla_session = mock.Mock()
         mock_bugzilla.Bugzilla.return_value = bugzilla_session
 
-        notifier = Bugzilla(server_url, username, password, api_key)
+        notifier = Bugzilla(server_url, api_key)
 
         mock_bugzilla.Bugzilla.assert_called_with(
             url=server_url, api_key=api_key, cookiefile=None, tokenfile=None
         )
 
-        assert notifier.bugzilla == bugzilla_session
-
-    @mock.patch("hotness.patchers.bugzilla.bugzilla")
-    def test_init_no_api_key(self, mock_bugzilla):
-        """
-        Assert that Bugzilla patcher object is initialized correctly when api_key is not provided.
-        """
-        server_url = "https://example.com/"
-        username = "Fabius@Bile.w40k"
-        password = "UltraSuperHyperPassword"
-        api_key = ""
-        bugzilla_session = mock.Mock()
-        mock_bugzilla.Bugzilla.return_value = bugzilla_session
-
-        notifier = Bugzilla(
-            server_url,
-            username,
-            password,
-            api_key,
-        )
-
-        mock_bugzilla.Bugzilla.assert_called_with(
-            url=server_url,
-            user=username,
-            password=password,
-            cookiefile=None,
-            tokenfile=None,
-        )
         assert notifier.bugzilla == bugzilla_session
 
     def test_init_no_authentication(self):
@@ -84,21 +54,16 @@ class TestBugzillaInit:
         if authentication info is not provided.
         """
         server_url = "https://example.com/"
-        username = ""
-        password = ""
         api_key = ""
 
         with pytest.raises(PatcherException) as exc:
             Bugzilla(
                 server_url,
-                username,
-                password,
                 api_key,
             )
 
         assert exc.value.message == (
-            "Authentication info not provided! Provide either 'username' and 'password' "
-            "or API key."
+            "Authentication info not provided! Provide API key."
         )
 
 
@@ -113,16 +78,12 @@ class TestBugzillaSubmitPatch:
         Create patcher instance for tests.
         """
         server_url = "https://example.com/"
-        username = "Fabius@Bile.w40k"
-        password = "UltraSuperHyperPassword"
         api_key = "some API key"
         bugzilla_session = mock.Mock()
         mock_bugzilla.Bugzilla.return_value = bugzilla_session
 
         self.patcher = Bugzilla(
             server_url,
-            username,
-            password,
             api_key,
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,8 +38,6 @@ full_config = {
         "bugzilla": {
             "enabled": False,
             "url": "https://partner-bugzilla.redhat.com_test",
-            "user": "",
-            "password": "",
             "api_key": "",
             "product": "",
             "version": "",
@@ -47,6 +45,7 @@ full_config = {
             "bug_status": "",
             "explanation_url": "https://fedoraproject.org/wiki/upstream_release_monitoring_test",
             "reporter": "",
+            "reporter_email": "",
             "short_desc_template": "",
             "description_template": "",
         },

--- a/tests/test_hotness_consumer.py
+++ b/tests/test_hotness_consumer.py
@@ -171,8 +171,7 @@ Based on the information from anitya: https://release-monitoring.org/project/%(p
         mock_bz_notifier_new.assert_called_with(
             server_url="https://partner-bugzilla.redhat.com",
             reporter="Upstream Release Monitoring",
-            username=None,
-            password=None,
+            email="upstream-release-monitoring@fedoraproject.org",
             api_key="",
             product="Fedora",
             keywords="FutureFeature, Triaged",
@@ -184,8 +183,6 @@ Based on the information from anitya: https://release-monitoring.org/project/%(p
 
         mock_bz_patcher_new.assert_called_with(
             server_url="https://partner-bugzilla.redhat.com",
-            username=None,
-            password=None,
             api_key="",
         )
 


### PR DESCRIPTION
Remove username and password authentication from Bugzilla code.
Change minimal version of python-bugzilla to 3.2.0.
Introduce reporter_email instead of username for searching.
See announcement e-mail for more info:
https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/U3PQNCLKA3R6GA2UI2EZP2OT4VAKVHBI/

Closes #401.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>