### PR TITLE
Remove python 3.7

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -52,10 +52,6 @@
             vars:
               dependencies:
                 - krb5-devel
-        - tox-python37:
-            vars:
-              dependencies:
-                - krb5-devel
         - tox-python38:
             vars:
               dependencies:

--- a/news/PR405.dev
+++ b/news/PR405.dev
@@ -1,0 +1,1 @@
+Remove Python 3.7

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,5 @@ setup(
     tests_require=get_requirements("dev-requirements.txt"),
     packages=find_packages(exclude=("hotness.tests", "hotness.tests.*")),
     test_suite="hotness.tests",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,lint,format,diff-cover,docs,bandit
+envlist = py38,py39,lint,format,diff-cover,docs,bandit
 
 [testenv]
 deps =


### PR DESCRIPTION
With introduction of Sphinx 4.4.0 the dependencies couldn't be satisfied on
Python 3.7, so it's probably time to remove it.

```
The conflict is caused by:
    flake8 4.0.1 depends on importlib-metadata<4.3; python_version < "3.8"
    pytest 6.2.5 depends on importlib-metadata>=0.12; python_version < "3.8"
    sphinx 4.4.0 depends on importlib-metadata>=4.4; python_version < "3.10"
```