### PR TITLE
Fix pytest 7.0.0 errors

### DIFF
--- a/tests/notifiers/test_bugzilla.py
+++ b/tests/notifiers/test_bugzilla.py
@@ -114,8 +114,7 @@ class TestBugzillaNotify:
     Test class for `hotness.notifiers.Bugzilla.notify` method.
     """
 
-    @mock.patch("hotness.notifiers.bugzilla.bugzilla")
-    def setup(self, mock_bugzilla):
+    def setup(self):
         """
         Create notifier instance for tests.
         """
@@ -128,18 +127,19 @@ class TestBugzillaNotify:
         version = "1.0"
         status = "NEW"
         bugzilla_session = mock.Mock()
-        mock_bugzilla.Bugzilla.return_value = bugzilla_session
+        with mock.patch("hotness.notifiers.bugzilla.bugzilla") as mock_bugzilla:
+            mock_bugzilla.Bugzilla.return_value = bugzilla_session
 
-        self.notifier = Bugzilla(
-            server_url,
-            reporter,
-            reporter_email,
-            api_key,
-            product,
-            keywords,
-            version,
-            status,
-        )
+            self.notifier = Bugzilla(
+                server_url,
+                reporter,
+                reporter_email,
+                api_key,
+                product,
+                keywords,
+                version,
+                status,
+            )
 
         assert self.notifier.bugzilla == bugzilla_session
 

--- a/tests/patchers/test_bugzilla.py
+++ b/tests/patchers/test_bugzilla.py
@@ -72,20 +72,20 @@ class TestBugzillaSubmitPatch:
     Test class for `hotness.patchers.Bugzilla.submit_patch` method.
     """
 
-    @mock.patch("hotness.patchers.bugzilla.bugzilla")
-    def setup(self, mock_bugzilla):
+    def setup(self):
         """
         Create patcher instance for tests.
         """
         server_url = "https://example.com/"
         api_key = "some API key"
-        bugzilla_session = mock.Mock()
-        mock_bugzilla.Bugzilla.return_value = bugzilla_session
+        with mock.patch("hotness.patchers.bugzilla.bugzilla") as mock_bugzilla:
+            bugzilla_session = mock.Mock()
+            mock_bugzilla.Bugzilla.return_value = bugzilla_session
 
-        self.patcher = Bugzilla(
-            server_url,
-            api_key,
-        )
+            self.patcher = Bugzilla(
+                server_url,
+                api_key,
+            )
 
         assert self.patcher.bugzilla == bugzilla_session
 

--- a/tests/test_hotness_consumer.py
+++ b/tests/test_hotness_consumer.py
@@ -212,47 +212,44 @@ class TestHotnessConsumerCall:
     Test class for `hotness.hotness_consumer.HotnessConsumer.__call__`.
     """
 
-    @mock.patch("hotness.hotness_consumer.Koji")
-    @mock.patch("hotness.hotness_consumer.Cache")
-    @mock.patch("hotness.hotness_consumer.bz_notifier")
-    @mock.patch("hotness.hotness_consumer.FedoraMessaging")
-    @mock.patch("hotness.hotness_consumer.bz_patcher")
-    @mock.patch("hotness.hotness_consumer.MDApi")
-    @mock.patch("hotness.hotness_consumer.Pagure")
-    @mock.patch("hotness.hotness_consumer.PDC")
-    def setup(
-        self,
-        mock_pdc_new,
-        mock_pagure_new,
-        mock_mdapi_new,
-        mock_bz_patcher_new,
-        mock_fm_new,
-        mock_bz_notifier_new,
-        mock_cache_new,
-        mock_koji_new,
-    ):
+    def setup(self):
         """
         Create hotness consumer for tests.
         It is accessible as `self.consumer`.
         """
-        mock_koji = mock.MagicMock()
-        mock_koji_new.return_value = mock_koji
-        mock_cache = mock.MagicMock()
-        mock_cache_new.return_value = mock_cache
-        mock_bugzilla_notifier = mock.Mock()
-        mock_bz_notifier_new.return_value = mock_bugzilla_notifier
-        mock_fedora_messaging = mock.Mock()
-        mock_fm_new.return_value = mock_fedora_messaging
-        mock_bugzilla_patcher = mock.Mock()
-        mock_bz_patcher_new.return_value = mock_bugzilla_patcher
-        mock_mdapi = mock.Mock()
-        mock_mdapi_new.return_value = mock_mdapi
-        mock_pagure = mock.Mock()
-        mock_pagure_new.return_value = mock_pagure
-        mock_pdc = mock.Mock()
-        mock_pdc_new.return_value = mock_pdc
+        with mock.patch("hotness.hotness_consumer.Koji") as mock_koji_new, mock.patch(
+            "hotness.hotness_consumer.Cache"
+        ) as mock_cache_new, mock.patch(
+            "hotness.hotness_consumer.bz_notifier"
+        ) as mock_bz_notifier_new, mock.patch(
+            "hotness.hotness_consumer.FedoraMessaging"
+        ) as mock_fm_new, mock.patch(
+            "hotness.hotness_consumer.bz_patcher"
+        ) as mock_bz_patcher_new, mock.patch(
+            "hotness.hotness_consumer.MDApi"
+        ) as mock_mdapi_new, mock.patch(
+            "hotness.hotness_consumer.Pagure"
+        ) as mock_pagure_new, mock.patch(
+            "hotness.hotness_consumer.PDC"
+        ) as mock_pdc_new:
+            mock_koji = mock.MagicMock()
+            mock_koji_new.return_value = mock_koji
+            mock_cache = mock.MagicMock()
+            mock_cache_new.return_value = mock_cache
+            mock_bugzilla_notifier = mock.Mock()
+            mock_bz_notifier_new.return_value = mock_bugzilla_notifier
+            mock_fedora_messaging = mock.Mock()
+            mock_fm_new.return_value = mock_fedora_messaging
+            mock_bugzilla_patcher = mock.Mock()
+            mock_bz_patcher_new.return_value = mock_bugzilla_patcher
+            mock_mdapi = mock.Mock()
+            mock_mdapi_new.return_value = mock_mdapi
+            mock_pagure = mock.Mock()
+            mock_pagure_new.return_value = mock_pagure
+            mock_pdc = mock.Mock()
+            mock_pdc_new.return_value = mock_pdc
 
-        self.consumer = HotnessConsumer()
+            self.consumer = HotnessConsumer()
 
     #
     #  anitya.project.version.update topic


### PR DESCRIPTION
The pytest 7.0.0 doesn't work well with mock.patch decorators in setup methods.
This commit changes them to with statements.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>