### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.10
   install:
     - requirements: dev-requirements.txt
     - method: pip

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -63,6 +63,10 @@
             vars:
               dependencies:
                 - krb5-devel
+        - tox-python310:
+            vars:
+              dependencies:
+                - krb5-devel
         - simple-tox-docs:
             vars:
               dependencies:

--- a/news/408.dev
+++ b/news/408.dev
@@ -1,0 +1,1 @@
+Add support for python 3.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = mypy,py38,py39,lint,format,diff-cover,docs,bandit
+envlist = mypy,py38,py39,py310,lint,format,diff-cover,docs,bandit
 
 [testenv]
 deps =


### PR DESCRIPTION
This commit will add python 3.10 to tox and zuul CI. It also updates readthedocs
configuration to python 3.10.

Closes #408

Signed-off-by: Michal Konečný <mkonecny@redhat.com>