### PR TITLE
Add build configuration for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,8 +15,13 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.10
   install:
     - requirements: dev-requirements.txt
     - method: pip
       path: .
+
+# Configure build environment
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"


### PR DESCRIPTION
Use build.tools.python instead of python.version. python.version was deprecated.
See https://docs.readthedocs.io/en/stable/config-file/v2.html#python-version