### PR TITLE
Define ports instead of using network_mode: host

### DIFF
--- a/container-compose.yml
+++ b/container-compose.yml
@@ -8,7 +8,6 @@ services:
       args:
         FEDORA_VERSION: 34
     container_name: "hotness"
-    network_mode: host
     volumes:
       - ./:/app
     privileged: true
@@ -23,8 +22,10 @@ services:
   rabbitmq:
     image: docker.io/library/rabbitmq:3.8.16-management-alpine
     container_name: "rabbitmq"
-    network_mode: host
     restart: unless-stopped
+    ports:
+      - "5672:5672"
+      - "15672:15672"
     healthcheck:
       test: [ "CMD", "nc", "-z", "localhost", "5672" ]
       interval: 3s
@@ -37,11 +38,11 @@ services:
   redis:
     image: docker.io/library/redis:6.0.9-alpine
     container_name: "redis"
-    network_mode: host
     restart: unless-stopped
+    ports:
+      - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 3s
       timeout: 3s
       retries: 15
-

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 bandit==1.7.4
-black==22.1.0
+black==22.3.0
 coverage==6.3.2
 diff-cover==6.4.5
 flake8==4.0.1


### PR DESCRIPTION
On Fedora 36 the podman-compose up is failing with multi-service deployment when
network_mode is set to host. Setting the specific ports makes the ports
available in both host and hotness container.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>