### PR TITLE
Use default tox job instead of using the custom one

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -43,39 +43,61 @@
 - project:
     check:
       jobs:
-        - tox-mypy:
+        - tox:
+            name: tox-mypy
             vars:
+              tox_envlist: mypy
               dependencies:
                 - krb5-devel
-        - tox-lint:
+            pre-run: ci/test-tox.yaml
+            nodeset:
+              nodes:
+                - name: test-node
+                  label: cloud-fedora-35
+        - tox:
+            name: tox-python37
             vars:
+              tox_envlist: py37
               dependencies:
                 - krb5-devel
-        - tox-format:
-            vars:
-              dependencies:
-                - krb5-devel
-        - tox-python38:
-            vars:
-              dependencies:
-                - krb5-devel
-        - tox-python39:
-            vars:
-              dependencies:
-                - krb5-devel
-        - tox-python310:
-            vars:
-              dependencies:
-                - krb5-devel
-        - simple-tox-docs:
-            vars:
-              dependencies:
-                - krb5-devel
-        - tox-bandit:
-            vars:
-              dependencies:
-                - krb5-devel
-        - tox-diff-cover:
-            vars:
-              dependencies:
-                - krb5-devel
+            pre-run: ci/test-tox.yaml
+            nodeset:
+              nodes:
+                - name: test-node
+                  label: cloud-fedora-35
+#        - tox-mypy:
+#            vars:
+#              dependencies:
+#                - krb5-devel
+#        - tox-lint:
+#            vars:
+#              dependencies:
+#                - krb5-devel
+#        - tox-format:
+#            vars:
+#              dependencies:
+#                - krb5-devel
+#        - tox-python38:
+#            vars:
+#              dependencies:
+#                - krb5-devel
+#        - tox-python39:
+#            vars:
+#              dependencies:
+#                - krb5-devel
+#        - tox-python310:
+#            vars:
+#              dependencies:
+#                - krb5-devel
+#        - simple-tox-docs:
+#            vars:
+#              dependencies:
+#                - krb5-devel
+#        - tox-bandit:
+#            vars:
+#              dependencies:
+#                - krb5-devel
+#        - tox-diff-cover:
+#            vars:
+#              dependencies:
+#                - krb5-devel

--- a/ci/test-tox.yaml
+++ b/ci/test-tox.yaml
@@ -22,7 +22,7 @@
       become: True
       when: (dependencies is defined) and (dependencies|length > 0)
 
-    - name: Run test
-      command: tox -e {{tox_env}}
-      args:
-        chdir: "{{ansible_user_dir}}/{{zuul.project.src_dir}}"
+#    - name: Run test
+#      command: tox -e {{tox_env}}
+#      args:
+#        chdir: "{{ansible_user_dir}}/{{zuul.project.src_dir}}"


### PR DESCRIPTION
It would be much more convenient to reuse existing zuul tox job instead of
creating multiple simple jobs.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>