### PR TITLE
Add PyPi and ReadTheDocs banners to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,10 @@
+.. image:: https://img.shields.io/pypi/v/the-new-hotness.svg
+  :target: https://pypi.org/project/the-new-hotness/
+
+.. image:: https://readthedocs.org/projects/the-new-hotness/badge/?version=latest
+  :alt: Documentation Status
+  :target: https://the-new-hotness.readthedocs.io/en/latest/?badge=latest
+
 the-new-hotness
 ---------------
 


### PR DESCRIPTION
It would be nice to have some quick indication of the version and documentation
status on main page of the project and this is a good option.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>