### PR TITLE
Add support for Anitya ProjectVersionUpdatedV2 message

### DIFF
--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -99,7 +99,9 @@ explanation_url = "https://fedoraproject.org/wiki/upstream_release_monitoring"
 short_desc_template = "%(name)s-%(latest_upstream)s is available"
 # Description of the issue (first comment on the issue)
 description_template = """
-Latest upstream release: %(latest_upstream)s
+Releases retrieved: %(retrieved_versions)s
+
+Upstream release that is considered latest: %(latest_upstream)s
 
 Current version/release in %(repo_name)s: %(repo_version)s-%(repo_release)s
 

--- a/devel/ansible/roles/hotness-dev/files/config.toml
+++ b/devel/ansible/roles/hotness-dev/files/config.toml
@@ -83,28 +83,30 @@ bug_status = "NEW"
 explanation_url = "https://fedoraproject.org/wiki/upstream_release_monitoring"
 short_desc_template = "%(name)s-%(latest_upstream)s is available"
 description_template = """
-Latest upstream release: %(latest_upstream)s
+Releases retrieved: %(retrieved_versions)s
+
+Upstream release that is considered latest: %(latest_upstream)s
 
 Current version/release in %(repo_name)s: %(repo_version)s-%(repo_release)s
 
 URL: %(url)s
 
 
-    Please consult the package updates policy before you
+Please consult the package updates policy before you
 issue an update to a stable branch:
-    https://docs.fedoraproject.org/en-US/fesco/Updates_Policy
+https://docs.fedoraproject.org/en-US/fesco/Updates_Policy
 
 
 More information about the service that created this bug can be found at:
 
-    %(explanation_url)s
+%(explanation_url)s
 
 
-    Please keep in mind that with any upstream change, there may also be packaging
-    changes that need to be made. Specifically, please remember that it is your
-    responsibility to review the new version to ensure that the licensing is still
-    correct and that no non-free or legally problematic items have been added
-    upstream.
+Please keep in mind that with any upstream change, there may also be packaging
+changes that need to be made. Specifically, please remember that it is your
+responsibility to review the new version to ensure that the licensing is still
+correct and that no non-free or legally problematic items have been added
+upstream.
 
 Based on the information from anitya: https://release-monitoring.org/project/%(projectid)s/
 """

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -15,6 +15,33 @@ package as `Monitoring status` option on the left side of the package repository
    The setting doesn't matter if the project is not created in
    `Anitya <https://release-monitoring.org>`_.
 
+Following is the explanation of the `Monitoring status` options:
+
+* *No-Monitoring* - Project will not be monitored and The New Hotness will drop any
+  update for this project
+
+* *Monitoring* - Project will be monitored by The New Hotness and Bugzilla ticket will
+  be created each time a new version will be discovered by Anitya.
+
+* *Monitoring and scratch builds* - Project will be monitored by The New Hotness and
+  Bugzilla notification will be created each time a new version will be discovered by
+  Anitya. Additionally a scratch build will be started for the new version.
+
+* *Monitoring all* - Project will be monitored by The New Hotness and Bugzilla
+  notification will be created for every version that will be discovered by Anitya.
+  This could cause issues with duplicates in case the version will be deleted and
+  retrieved again in Anitya.
+
+* *Monitoring all and scratch builds* - Project will be monitored by The New Hotness
+  and Bugzilla notification will be created for every version that will be discovered
+  by Anitya. Additionally a scratch build will be started for the newest version retrieved,
+  if the version is newer than the one already available in
+  `mdapi <https://pagure.io/mdapi>`_. This could cause issues with duplicates in case
+  the version will be deleted and retrieved again in Anitya.
+
+.. note::
+   The *Monitoring all* and *Monitoring all and scratch builds* options are supported by
+   The New Hotness, but not yet available on `dist git <https://src.fedoraproject.org>`_.
 
 Creating a project in Anitya
 ----------------------------

--- a/hotness/config.py
+++ b/hotness/config.py
@@ -65,7 +65,9 @@ DEFAULTS = dict(
         reporter_email="upstream-release-monitoring@fedoraproject.org",
         short_desc_template="%(name)s-%(latest_upstream)s is available",
         description_template="""
-Latest upstream release: %(latest_upstream)s
+Releases retrieved: %(retrieved_versions)s
+
+Upstream release that is considered latest: %(latest_upstream)s
 
 Current version/release in %(repo_name)s: %(repo_version)s-%(repo_release)s
 

--- a/news/230.feature
+++ b/news/230.feature
@@ -1,0 +1,1 @@
+Change in the-new-hotness to work with multiple versions notified at once

--- a/tests/fixtures/anitya.project.version.update.v2/fedora_mapping.json
+++ b/tests/fixtures/anitya.project.version.update.v2/fedora_mapping.json
@@ -2,7 +2,6 @@
   "distro": null,
   "message": {
     "agent": "anitya",
-    "odd_change": false,
     "old_version": "0.99.3",
     "packages": [
       {
@@ -109,7 +108,10 @@
         "0.2.1"
       ]
     },
-    "upstream_version": "1.0.4",
+    "upstream_versions": [
+        "1.0.4",
+        "0.99.3"
+    ],
     "versions": [
       "1.0.4",
       "0.99.3",
@@ -184,6 +186,9 @@
       "0.3.1",
       "0.3",
       "0.2.1"
+    ],
+    "stable_versions": [
+      "1.0.4"
     ]
   },
   "project": {

--- a/tests/fixtures/anitya.project.version.update.v2/no_mapping.json
+++ b/tests/fixtures/anitya.project.version.update.v2/no_mapping.json
@@ -2,7 +2,6 @@
   "distro": null,
   "message": {
     "agent": "anitya",
-    "odd_change": false,
     "old_version": "",
     "packages": [],
     "project": {
@@ -20,9 +19,14 @@
         "0.17.0"
       ]
     },
-    "upstream_version": "0.17.0",
+    "upstream_versions": [
+        "0.17.0"
+    ],
     "versions": [
       "0.17.0"
+    ],
+    "stable_versions": [
+        "0.17.0"
     ]
   },
   "project": {

--- a/tests/validators/test_pagure.py
+++ b/tests/validators/test_pagure.py
@@ -85,6 +85,7 @@ class TestPagureValidate:
         )
 
         assert result["monitoring"] is True
+        assert result["all_versions"] is False
         assert result["scratch_build"] is False
 
     def test_validate_no_monitoring(self):
@@ -113,6 +114,7 @@ class TestPagureValidate:
         )
 
         assert result["monitoring"] is False
+        assert result["all_versions"] is False
         assert result["scratch_build"] is False
 
     def test_validate_monitoring_scratch(self):
@@ -141,6 +143,67 @@ class TestPagureValidate:
         )
 
         assert result["monitoring"] is True
+        assert result["all_versions"] is False
+        assert result["scratch_build"] is True
+
+    def test_validate_monitoring_all(self):
+        """
+        Assert that validation returns correct output when monitoring for all versions
+        is set.
+        """
+        # Mock requests_session
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "monitoring": "monitoring-all",
+        }
+        self.validator.requests_session.get.return_value = response
+
+        # Prepare package
+        package = Package(name="test", version="1.1", distro="Fedora")
+
+        result = self.validator.validate(package)
+
+        # Parameters for requests get call
+        timeout = (5, 20)
+
+        self.validator.requests_session.get.assert_called_with(
+            self.validator.url + "/_dg/anitya/rpms/{}".format(package.name),
+            timeout=timeout,
+        )
+
+        assert result["monitoring"] is True
+        assert result["all_versions"] is True
+        assert result["scratch_build"] is False
+
+    def test_validate_monitoring_all_scratch(self):
+        """
+        Assert that validation returns correct output when monitoring for all versions
+        with scratch build is set.
+        """
+        # Mock requests_session
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "monitoring": "monitoring-all-scratch",
+        }
+        self.validator.requests_session.get.return_value = response
+
+        # Prepare package
+        package = Package(name="test", version="1.1", distro="Fedora")
+
+        result = self.validator.validate(package)
+
+        # Parameters for requests get call
+        timeout = (5, 20)
+
+        self.validator.requests_session.get.assert_called_with(
+            self.validator.url + "/_dg/anitya/rpms/{}".format(package.name),
+            timeout=timeout,
+        )
+
+        assert result["monitoring"] is True
+        assert result["all_versions"] is True
         assert result["scratch_build"] is True
 
     def test_validate_monitoring_is_missing(self):
@@ -167,6 +230,7 @@ class TestPagureValidate:
         )
 
         assert result["monitoring"] is False
+        assert result["all_versions"] is False
         assert result["scratch_build"] is False
 
     def test_validate_invalid_monitoring_value(self):
@@ -195,6 +259,7 @@ class TestPagureValidate:
         )
 
         assert result["monitoring"] is False
+        assert result["all_versions"] is False
         assert result["scratch_build"] is False
 
     def test_validate_response_not_ok(self):


### PR DESCRIPTION
This new message topic sends multiple versions at once instead of just one new
version. This commit will update hotness to be able to notify user about other
releases if they are found by Anitya.

It also adds support for new dist-git monitoring options, which allows
maintainers to get notifications about every version that is retrieved by
Anitya, even if it's not considered latest.

Closes #230 