### PR TITLE
Clean devel environments

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -33,7 +33,6 @@ ENV FEDORA_MESSAGING_CONF=/root/config.toml
 
 # Install local packages in editable mode
 RUN pip3 install -e /app
-RUN pip3 install -e /app/hotness_schema
 
 # Comment out the line that starts with 'default_ccache_name'
 # for preventing following error: `kinit: Invalid UID in persistent keyring name while getting default ccache`

--- a/devel/ansible/roles/hotness-dev/tasks/main.yml
+++ b/devel/ansible/roles/hotness-dev/tasks/main.yml
@@ -17,9 +17,7 @@
     name: [
       # Packages needed for running test in tox
       krb5-devel,
-      libcurl-devel,
       gcc,
-      openssl-devel,
       # Packages needed for the-new-hotness development
       python3-black,
       python3-flake8,
@@ -55,7 +53,6 @@
   pip:
     name: [
       "file:///home/{{ ansible_env.SUDO_USER }}/devel/",
-      "file:///home/{{ ansible_env.SUDO_USER }}/devel/hotness_schema/"
     ]
     extra_args: '-e'
     executable: pip-3


### PR DESCRIPTION
Remove schema from both podman and vagrant devel environments.

Clean up packages for vagrant.

Closes #326

Signed-off-by: Michal Konečný <mkonecny@redhat.com>