### PR TITLE
Add link to repository to bugzilla notification

### DIFF
--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -100,21 +100,15 @@ short_desc_template = "%(name)s-%(latest_upstream)s is available"
 # Description of the issue (first comment on the issue)
 description_template = """
 Releases retrieved: %(retrieved_versions)s
-
 Upstream release that is considered latest: %(latest_upstream)s
-
 Current version/release in %(repo_name)s: %(repo_version)s-%(repo_release)s
-
 URL: %(url)s
-
 
 Please consult the package updates policy before you
 issue an update to a stable branch:
 https://docs.fedoraproject.org/en-US/fesco/Updates_Policy
 
-
 More information about the service that created this bug can be found at:
-
 %(explanation_url)s
 
 
@@ -125,6 +119,9 @@ correct and that no non-free or legally problematic items have been added
 upstream.
 
 Based on the information from anitya: https://release-monitoring.org/project/%(projectid)s/
+
+To change the monitoring settings for the project, please visit:
+%(dist_git_url)s
 """
 
 # Configuration of Koji for the-new-hotness

--- a/devel/ansible/roles/hotness-dev/files/config.toml
+++ b/devel/ansible/roles/hotness-dev/files/config.toml
@@ -84,21 +84,15 @@ explanation_url = "https://fedoraproject.org/wiki/upstream_release_monitoring"
 short_desc_template = "%(name)s-%(latest_upstream)s is available"
 description_template = """
 Releases retrieved: %(retrieved_versions)s
-
 Upstream release that is considered latest: %(latest_upstream)s
-
 Current version/release in %(repo_name)s: %(repo_version)s-%(repo_release)s
-
 URL: %(url)s
-
 
 Please consult the package updates policy before you
 issue an update to a stable branch:
 https://docs.fedoraproject.org/en-US/fesco/Updates_Policy
 
-
 More information about the service that created this bug can be found at:
-
 %(explanation_url)s
 
 
@@ -109,6 +103,9 @@ correct and that no non-free or legally problematic items have been added
 upstream.
 
 Based on the information from anitya: https://release-monitoring.org/project/%(projectid)s/
+
+To change the monitoring settings for the project, please visit:
+%(dist_git_url)s
 """
 
 [consumer_config.koji]

--- a/hotness/config.py
+++ b/hotness/config.py
@@ -66,23 +66,16 @@ DEFAULTS = dict(
         short_desc_template="%(name)s-%(latest_upstream)s is available",
         description_template="""
 Releases retrieved: %(retrieved_versions)s
-
 Upstream release that is considered latest: %(latest_upstream)s
-
 Current version/release in %(repo_name)s: %(repo_version)s-%(repo_release)s
-
 URL: %(url)s
-
 
 Please consult the package updates policy before you
 issue an update to a stable branch:
 https://docs.fedoraproject.org/en-US/fesco/Updates_Policy
 
-
 More information about the service that created this bug can be found at:
-
 %(explanation_url)s
-
 
 Please keep in mind that with any upstream change, there may also be packaging
 changes that need to be made. Specifically, please remember that it is your
@@ -91,6 +84,9 @@ correct and that no non-free or legally problematic items have been added
 upstream.
 
 Based on the information from anitya: https://release-monitoring.org/project/%(projectid)s/
+
+To change the monitoring settings for the project, please visit:
+%(dist_git_url)s
 """,
     ),
     # Koji configuration

--- a/hotness/hotness_consumer.py
+++ b/hotness/hotness_consumer.py
@@ -74,6 +74,7 @@ class HotnessConsumer(object):
     Attributes:
         short_desc_template (str): Short description template for notifier
         description_template (str): Template for the message content
+        dist_git_url (str): URL for dist-git server
         distro (str): Distro to watch the updates for
         builder_koji (`Koji`): Koji builder to use for scratch builds
         database_cache (`Cache`): Database that will be used for holding key/value
@@ -117,6 +118,7 @@ class HotnessConsumer(object):
         # Initialize attributes
         self.short_desc_template = config["bugzilla"]["short_desc_template"]
         self.description_template = config["bugzilla"]["description_template"]
+        self.dist_git_url = config["dist_git_url"]
         self.explanation_url = config["bugzilla"]["explanation_url"]
         self.distro = config["distro"]
         self.repoid = config["repoid"]
@@ -597,6 +599,9 @@ class HotnessConsumer(object):
         upstream_versions = latest_upstream
         if retrieved_versions:
             upstream_versions = ", ".join(retrieved_versions)
+
+        # Prepare dist-git URL
+        dist_git_url = self.dist_git_url + "/rpms/" + package.name
         # Prepare message for bugzilla
         description = self.description_template % dict(
             latest_upstream=package.version,
@@ -607,6 +612,7 @@ class HotnessConsumer(object):
             url=project_homepage,
             explanation_url=self.explanation_url,
             projectid=project_id,
+            dist_git_url=dist_git_url,
         )
         notify_request = NotifyRequest(
             package=package,

--- a/news/324.feature
+++ b/news/324.feature
@@ -1,0 +1,1 @@
+Add link to monitoring setting to Bugzilla notification

--- a/tests/test_hotness_consumer.py
+++ b/tests/test_hotness_consumer.py
@@ -102,27 +102,21 @@ class TestHotnessConsumerInit:
         assert (
             consumer.short_desc_template == "%(name)s-%(latest_upstream)s is available"
         )
+        assert consumer.dist_git_url == "https://src.fedoraproject.org"
         assert (
             consumer.description_template
             == """
 Releases retrieved: %(retrieved_versions)s
-
 Upstream release that is considered latest: %(latest_upstream)s
-
 Current version/release in %(repo_name)s: %(repo_version)s-%(repo_release)s
-
 URL: %(url)s
-
 
 Please consult the package updates policy before you
 issue an update to a stable branch:
 https://docs.fedoraproject.org/en-US/fesco/Updates_Policy
 
-
 More information about the service that created this bug can be found at:
-
 %(explanation_url)s
-
 
 Please keep in mind that with any upstream change, there may also be packaging
 changes that need to be made. Specifically, please remember that it is your
@@ -131,6 +125,9 @@ correct and that no non-free or legally problematic items have been added
 upstream.
 
 Based on the information from anitya: https://release-monitoring.org/project/%(projectid)s/
+
+To change the monitoring settings for the project, please visit:
+%(dist_git_url)s
 """
         )
         assert (
@@ -326,6 +323,7 @@ class TestHotnessConsumerCall:
                 retrieved_versions=", ".join(
                     message.body["message"]["upstream_versions"]
                 ),
+                dist_git_url=self.consumer.dist_git_url + "/rpms/" + package.name,
             ),
             {"bz_short_desc": "flatpak-1.0.4 is available"},
         )
@@ -393,6 +391,7 @@ class TestHotnessConsumerCall:
                 retrieved_versions=", ".join(
                     message.body["message"]["upstream_versions"]
                 ),
+                dist_git_url=self.consumer.dist_git_url + "/rpms/" + package.name,
             ),
             {"bz_short_desc": "flatpak-1.0.4 is available"},
         )
@@ -454,6 +453,7 @@ class TestHotnessConsumerCall:
                 retrieved_versions=", ".join(
                     message.body["message"]["upstream_versions"]
                 ),
+                dist_git_url=self.consumer.dist_git_url + "/rpms/" + package.name,
             ),
             {"bz_short_desc": "flatpak-1.0.4 is available"},
         )
@@ -523,6 +523,7 @@ class TestHotnessConsumerCall:
                 retrieved_versions=", ".join(
                     message.body["message"]["upstream_versions"]
                 ),
+                dist_git_url=self.consumer.dist_git_url + "/rpms/" + package.name,
             ),
             {"bz_short_desc": "flatpak-1.0.4 is available"},
         )
@@ -594,6 +595,7 @@ class TestHotnessConsumerCall:
                 explanation_url=self.consumer.explanation_url,
                 projectid=message.body["project"]["id"],
                 retrieved_versions="1.0.4",
+                dist_git_url=self.consumer.dist_git_url + "/rpms/" + package.name,
             ),
             {"bz_short_desc": "flatpak-1.0.4 is available"},
         )
@@ -667,6 +669,7 @@ class TestHotnessConsumerCall:
                 explanation_url=self.consumer.explanation_url,
                 projectid=message.body["project"]["id"],
                 retrieved_versions="0.99.3, 0.99.2",
+                dist_git_url=self.consumer.dist_git_url + "/rpms/" + package.name,
             ),
             {"bz_short_desc": "flatpak-0.99.3 is available"},
         )
@@ -780,6 +783,9 @@ class TestHotnessConsumerCall:
                         retrieved_versions=", ".join(
                             message.body["message"]["upstream_versions"]
                         ),
+                        dist_git_url=self.consumer.dist_git_url
+                        + "/rpms/"
+                        + package.name,
                     ),
                     {"bz_short_desc": "flatpak-1.0.4 is available"},
                 ),
@@ -860,6 +866,9 @@ class TestHotnessConsumerCall:
                         retrieved_versions=", ".join(
                             message.body["message"]["upstream_versions"]
                         ),
+                        dist_git_url=self.consumer.dist_git_url
+                        + "/rpms/"
+                        + package.name,
                     ),
                     {"bz_short_desc": "flatpak-1.0.4 is available"},
                 ),
@@ -945,6 +954,9 @@ class TestHotnessConsumerCall:
                         retrieved_versions=", ".join(
                             message.body["message"]["upstream_versions"]
                         ),
+                        dist_git_url=self.consumer.dist_git_url
+                        + "/rpms/"
+                        + package.name,
                     ),
                     {"bz_short_desc": "flatpak-1.0.4 is available"},
                 ),
@@ -1021,6 +1033,9 @@ class TestHotnessConsumerCall:
                         retrieved_versions=", ".join(
                             message.body["message"]["upstream_versions"]
                         ),
+                        dist_git_url=self.consumer.dist_git_url
+                        + "/rpms/"
+                        + package.name,
                     ),
                     {"bz_short_desc": "flatpak-1.0.4 is available"},
                 ),
@@ -1131,6 +1146,7 @@ class TestHotnessConsumerCall:
                 retrieved_versions=", ".join(
                     message.body["message"]["upstream_versions"]
                 ),
+                dist_git_url=self.consumer.dist_git_url + "/rpms/" + package.name,
             ),
             {"bz_short_desc": "flatpak-1.0.4 is available"},
         )
@@ -1357,6 +1373,7 @@ class TestHotnessConsumerCall:
                 retrieved_versions=", ".join(
                     message.body["message"]["upstream_versions"]
                 ),
+                dist_git_url=self.consumer.dist_git_url + "/rpms/" + package.name,
             ),
             {"bz_short_desc": "flatpak-1.0.4 is available"},
         )


### PR DESCRIPTION
Currently the notification is missing the link to fedora package repository
which contains settings for the monitoring itself.

This commit is adding the link to bugzilla notification.

Closes #324

Signed-off-by: Michal Konečný <mkonecny@redhat.com>