### PR TITLE
Use the correct error message before build starts

### DIFF
--- a/hotness/exceptions/builder_exception.py
+++ b/hotness/exceptions/builder_exception.py
@@ -55,7 +55,7 @@ class BuilderException(BaseHotnessException):
         """
         message = ""
         if self.value:
-            if "build_id" in self.value:
+            if "build_id" in self.value and not self.value["build_id"] == 0:
                 message = (
                     "Build started, but failure happened "
                     "during post build operations:\n{}\n"

--- a/news/456.bug
+++ b/news/456.bug
@@ -1,0 +1,1 @@
+Wrong error message when the build didn't started yet

--- a/tests/exceptions/test_builder_exception.py
+++ b/tests/exceptions/test_builder_exception.py
@@ -83,6 +83,17 @@ class TestBuilderExceptionStr:
             "This error is a tech heresy!\n"
         )
 
+    def test_str_build_id_zero(self):
+        """
+        Assert that the string representation of exception is correct
+        when build id is available, but the value is still 0.
+        """
+        exception = BuilderException(
+            "This error is a tech heresy!", value={"build_id": 0}
+        )
+
+        assert str(exception) == ("Build failed:\n" "This error is a tech heresy!\n")
+
     def test_str_std_err_out(self):
         """
         Assert that the string representation of exception is correct


### PR DESCRIPTION
Hotness didn't checked the build_id variable for value when creating error
message and erroneously reported that the build already started.

This commit is adding the check for zero together with new test.

Fixes #456

Signed-off-by: Michal Konečný <mkonecny@redhat.com>