### PR TITLE
Add support for redis

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -17,7 +17,8 @@ RUN dnf install -y fedora-messaging
 # Python3 and packages
 RUN dnf install -y python3 python3-pip python3-bugzilla \
     python3-koji python3-requests \
-    python3-black python3-flake8 python3-sphinx
+    python3-black python3-flake8 python3-sphinx \
+    python3-redis
 
 # Development tools (for doing stuff inside of the container)
 RUN dnf install -y vim-enhanced tox python3-rpdb gcc

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -14,6 +14,7 @@ callback = "hotness.hotness_consumer:HotnessConsumer"
 queue = "the-new-hotness"
 exchange = "amq.topic"
 routing_keys = [
+    "org.release-monitoring.prod.anitya.project.version.update.v2",
     "org.release-monitoring.prod.anitya.project.version.update",
     "org.fedoraproject.prod.buildsys.task.state.change",
 ]

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -72,6 +72,18 @@ read_timeout = 15
 # that failed for any reason (e.g. read timeout, DNS error, etc)
 requests_retries = 3
 
+# Redis configuration for the-new-hotness
+[consumer_config.redis]
+# Hostname of the redis server
+hostname = "localhost"
+# Port of the redis server
+port = 6379
+# Password for redis server
+password = ""
+# Expiration time in seconds for entries put in redis database
+# Default: 1 day
+expiration = 86400
+
 # Bugzilla configuration for the-new-hotness
 [consumer_config.bugzilla]
 # If the bugzilla wrapper is enabled, currently ignored

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -36,7 +36,7 @@ services:
       - RABBITMQ_DEFAULT_PASS=hotness
 
   redis:
-    image: docker.io/library/redis:6.0.9-alpine
+    image: docker.io/library/redis:7.0.0-alpine
     container_name: "redis"
     restart: unless-stopped
     ports:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,3 +13,4 @@ sphinx==4.5.0
 # Mypy test requirements
 mypy==0.950
 types-requests==2.27.25
+types-redis==4.2.2

--- a/devel/ansible/roles/hotness-dev/files/config.toml
+++ b/devel/ansible/roles/hotness-dev/files/config.toml
@@ -14,6 +14,7 @@ callback = "hotness.hotness_consumer:HotnessConsumer"
 queue = "the-new-hotness"
 exchange = "amq.topic"
 routing_keys = [
+    "org.release-monitoring.prod.anitya.project.version.update.v2",
     "org.release-monitoring.prod.anitya.project.version.update",
     "org.fedoraproject.prod.buildsys.task.state.change",
 ]

--- a/devel/ansible/roles/hotness-dev/files/config.toml
+++ b/devel/ansible/roles/hotness-dev/files/config.toml
@@ -69,8 +69,18 @@ read_timeout = 15
 # The number of times the-new-hotness should retry a network request
 # that failed for any reason (e.g. read timeout, DNS error, etc)
 requests_retries = 3
-# If true, publish fedmsg messages instead of fedora-messaging messages
-legacy_messaging = false
+
+# Redis configuration for the-new-hotness
+[consumer_config.redis]
+# Hostname of the redis server
+hostname = "redis"
+# Port of the redis server
+port = 6379
+# Password for redis server
+password = ""
+# Expiration time in seconds for entries put in redis database
+# Default: 1 day
+expiration = 86400
 
 [consumer_config.bugzilla]
 enabled = true
@@ -127,16 +137,3 @@ user_email = [
 opts = {scratch = true}
 priority = 30
 target_tag = "rawhide"
-# These are errors that we won't scream about.
-passable_errors = [
-    # This is the packager's problem, not ours.
-    "unclosed macro or bad line continuation"
-]
-
-[consumer_config.anitya]
-url = "https://release-monitoring.org"
-
-[consumer_config.cache]
-backend = "dogpile.cache.dbm"
-expiration_time = 300
-arguments = {filename = "/var/tmp/the-new-hotness-cache.dbm"}

--- a/devel/ansible/roles/hotness-dev/tasks/main.yml
+++ b/devel/ansible/roles/hotness-dev/tasks/main.yml
@@ -21,6 +21,7 @@
       # Packages needed for the-new-hotness development
       python3-black,
       python3-flake8,
+      python3-redis,
       python3-sphinx,
       rabbitmq-server
     ]
@@ -87,3 +88,4 @@
   become_user: "{{ ansible_env.SUDO_USER }}"
   command: systemctl --user daemon-reload
 
+- import_tasks: redis.yml

--- a/devel/ansible/roles/hotness-dev/tasks/redis.yml
+++ b/devel/ansible/roles/hotness-dev/tasks/redis.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Install redis package
+  dnf:
+    name: redis
+    state: present
+
+- name: Update /etc/hosts
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    line: "127.0.0.1 redis"
+
+- name: Enable Redis server
+  systemd:
+    name: redis
+    state: started
+    enabled: yes

--- a/docs/admin-guide.rst
+++ b/docs/admin-guide.rst
@@ -41,15 +41,10 @@ external systems:
   The New Hotness is consuming fedora messages from Anitya and looking for updates
   of the packages that we want to process.
   
-* cache
+* `Redis <https://redis.io/>`_
 
-  This is not really an external system, but it's used as one by The New Hotness.
-  Local cache is used to store the information about build if we start a scratch build.
-  This will help us to keep track of the builds and correctly react to buildsys fedora
-  message.
-
-.. note::
-   Local cache will be replaced by Redis in future.
+  Redis is used as a cache for saving data that we would need later by the-new-hotness. For
+  example koji build id mapping to bugzilla ticket.
 
 * `koji <https://pagure.io/koji/>`_
 

--- a/docs/ca-design.rst
+++ b/docs/ca-design.rst
@@ -296,11 +296,11 @@ defined in use cases layer.
 
   Directory containing external systems acting like a database for the-new-hotness.
 
-  * cache.py
+  * **cache.py**
 
     This class contains cache for storing key/value entries. Inherits from `database.py`.
 
-  * redis.py
+  * **redis.py**
 
     This class contains every method that is needed to insert, retrieve data from Redis database.
     Inherits from `database.py`.

--- a/hotness/config.py
+++ b/hotness/config.py
@@ -51,6 +51,13 @@ DEFAULTS = dict(
     # The number of times the-new-hotness should retry a network request
     # that failed for any reason (e.g. read timeout, DNS error, etc)
     requests_retries=3,
+    # Redis configuration
+    redis=dict(
+        hostname="localhost",
+        port=6379,
+        password="",
+        expiration=86400,
+    ),
     # Bugzilla configuration
     bugzilla=dict(
         enabled=True,

--- a/hotness/databases/__init__.py
+++ b/hotness/databases/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021 Red Hat, Inc.
+# Copyright (C) 2021-2022 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,3 +17,4 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 from .database import Database  # noqa: F401
 from .cache import Cache  # noqa: F401
+from .redis import Redis  # noqa: F401

--- a/hotness/databases/redis.py
+++ b/hotness/databases/redis.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+import redis
+
+from . import Database
+
+
+class Redis(Database):
+    """
+    Wrapper around redis-py library.
+    It establishes connection with Redis database and allows user to
+    save and retrieves values from it.
+
+    Attributes:
+        redis (`redis.Redis`): Redis object to use for communication with Redis
+            database
+        expiration_time (int): Expiration time to use on keys (in seconds)
+    """
+
+    def __init__(
+        self, hostname: str, port: int, password: str, expiration_time: int
+    ) -> None:
+        """
+        Class constructor.
+
+        Params:
+            hostname: Hostname of the Redis database
+            port: Port of the Redis database
+            password: Password to use for connecting to Redis database
+            expiration_time: Expiration time to set for keys (in seconds)
+        """
+        self.redis = redis.Redis(host=hostname, port=port, password=password)
+
+        self.expiration_time = expiration_time
+
+    def insert(self, key: str, value: str) -> dict:
+        """
+        It inserts key/value pair to redis. If key is already in redis
+        it will change the value.
+
+        Params:
+            key: Key to insert to database
+            value: Value for the key to add
+
+        Returns:
+            Dictionary containing key/value pairs.
+            Example:
+            {
+              "key": "key", # Key we added/edited in database
+              "value": "value", # New value added to the key
+              "old_value": "old_value" # Old value for the key, empty if the key is new
+            }
+        """
+        output = {"key": key, "value": value, "old_value": ""}
+
+        old_value = self.redis.set(key, value, ex=self.expiration_time, get=True)
+
+        if old_value:
+            output["old_value"] = str(old_value)
+
+        return output
+
+    def retrieve(self, key: str) -> dict:
+        """
+        Retrieve value for a key in database. If the key is not available
+        it returns empty value represented by "".
+
+        Params:
+            key: Key to retrieve from database
+
+        Returns:
+            Dictionary containing key/value pairs.
+            Example:
+            {
+              "key": "key", # Key we retrieved from database
+              "value": "value" # Retrieved value for the key
+            }
+        """
+        output = {"key": key, "value": ""}
+
+        value = self.redis.get(key)
+
+        if value:
+            output["value"] = str(value)
+
+        return output

--- a/news/323.feature
+++ b/news/323.feature
@@ -1,0 +1,1 @@
+Add Redis as cache for builds we are watching

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ fedora-messaging>=2.0.1, <4.0.0
 fedora_messaging_the_new_hotness_schema>=1.0.1, <2.0.0
 koji>=1.21.0, <2.0.0
 python-bugzilla>=3.2.0, <4.0.0
+redis>=4.3.1, <5.0.0
 requests>=2.22.0, <3.0.0

--- a/tests/databases/test_redis.py
+++ b/tests/databases/test_redis.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+import mock
+
+from hotness.databases import Redis
+
+
+class TestRedisInit:
+    """
+    Test class for `hotness.databases.Redis.__init__` method.
+    """
+
+    @mock.patch("hotness.databases.redis.redis")
+    def test_init(self, mock_redis):
+        """
+        Assert that database object is correctly initialized.
+        """
+        # Preparation
+        hostname = "hostname"
+        port = 1234
+        password = "password"
+        expiration_time = 86400
+        redis_mock_instance = mock.Mock()
+        mock_redis.Redis.return_value = redis_mock_instance
+
+        # Test
+        database = Redis(
+            hostname=hostname,
+            port=port,
+            password=password,
+            expiration_time=expiration_time,
+        )
+
+        # Asserts
+        mock_redis.Redis.assert_called_with(host=hostname, port=port, password=password)
+
+        assert database.redis == redis_mock_instance
+        assert database.expiration_time == expiration_time
+
+
+class TestRedisInsert:
+    """
+    Test class for `hotness.databases.Redis.insert` method.
+    """
+
+    def setup(self):
+        """
+        Create database instance for tests.
+        """
+        with mock.patch("hotness.databases.redis.redis") as mock_redis:
+            redis_mock_instance = mock.Mock()
+            mock_redis.Redis.return_value = redis_mock_instance
+
+            self.database = Redis(
+                hostname="", port=1234, password="", expiration_time=86400
+            )
+
+    def test_insert(self):
+        """
+        Assert that insert works correctly.
+        """
+        # Preparation
+        key = "key"
+        value = "value"
+
+        self.database.redis.set.return_value = None
+
+        # Test
+        output = self.database.insert(key, value)
+
+        # Asserts
+        assert output == {"key": key, "value": value, "old_value": ""}
+        self.database.redis.set.assert_called_with(
+            key, value, ex=self.database.expiration_time, get=True
+        )
+
+    def test_insert_key_already_exists(self):
+        """
+        Assert that insert changes the value if key is already present.
+        """
+        # Preparation
+        key = "key"
+        old_value = "old_value"
+        value = "value"
+
+        self.database.redis.set.return_value = old_value
+
+        # Test
+        output = self.database.insert(key, value)
+
+        # Asserts
+        assert output == {"key": key, "value": value, "old_value": old_value}
+        self.database.redis.set.assert_called_with(
+            key, value, ex=self.database.expiration_time, get=True
+        )
+
+
+class TestRedisRetrieve:
+    """
+    Test class for `hotness.databases.Redis.retrieve` method.
+    """
+
+    def setup(self):
+        """
+        Create database instance for tests.
+        """
+        with mock.patch("hotness.databases.redis.redis") as mock_redis:
+            redis_mock_instance = mock.Mock()
+            mock_redis.Redis.return_value = redis_mock_instance
+
+            self.database = Redis(
+                hostname="", port=1234, password="", expiration_time=86400
+            )
+
+    def test_retrieve(self):
+        """
+        Assert that retrieve works correctly.
+        """
+        # Preparation
+        key = "key"
+        value = "value"
+
+        self.database.redis.get.return_value = value
+
+        # Test
+        output = self.database.retrieve(key)
+
+        # Asserts
+        assert output == {"key": key, "value": value}
+        self.database.redis.get.assert_called_with(key)
+
+    def test_retrieve_key_is_missing(self):
+        """
+        Assert that retrieve returns empty value, if key is not found in database.
+        """
+        # Preparation
+        key = "key"
+
+        self.database.redis.get.return_value = None
+
+        # Test
+        output = self.database.retrieve(key)
+
+        # Asserts
+        assert output == {"key": key, "value": ""}
+        self.database.redis.get.assert_called_with(key)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,6 +35,12 @@ full_config = {
         "connect_timeout": 30,
         "read_timeout": 30,
         "requests_retries": 1,
+        "redis": {
+            "hostname": "localhost",
+            "port": 6379,
+            "password": "",
+            "expiration": 86400,
+        },
         "bugzilla": {
             "enabled": False,
             "url": "https://partner-bugzilla.redhat.com_test",


### PR DESCRIPTION
Redis will be used instead of local cache, which will allow us to easily
increase the number of hotness instances without worries about losing data about
builds.

Closes #323

Signed-off-by: Michal Konečný <mkonecny@redhat.com>