### PR TITLE
Update container dev environment to Fedora 36

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN dnf upgrade --refresh -y
 
 # Kerberos packages
-RUN dnf install -y krb5-devel
+RUN dnf install -y krb5-devel krb5-workstation fedora-packager-kerberos
 
 # Fedora Messaging
 RUN dnf install -y fedora-messaging
@@ -21,7 +21,7 @@ RUN dnf install -y python3 python3-pip python3-bugzilla \
     python3-redis
 
 # Development tools (for doing stuff inside of the container)
-RUN dnf install -y vim-enhanced tox python3-rpdb gcc
+RUN dnf install -y vim-enhanced tox python3-rpdb gcc git
 
 # Packages that are required for releasing
 RUN pip3 install wheel twine towncrier

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Containerfile.dev
       args:
-        FEDORA_VERSION: 34
+        FEDORA_VERSION: 36
     container_name: "hotness"
     volumes:
       - ./:/app

--- a/news/PR465.dev
+++ b/news/PR465.dev
@@ -1,0 +1,1 @@
+Update podman dev environment to Fedora 36


### PR DESCRIPTION
Also add packages that are needed to get kerberos token for fedora.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>