### PR TITLE
Add missing packages to podman dev environment

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -14,6 +14,9 @@ RUN dnf install -y krb5-devel krb5-workstation fedora-packager-kerberos
 # Fedora Messaging
 RUN dnf install -y fedora-messaging
 
+# RPM tools needed by hotness
+RUN dnf install -y fedpkg rpmdevtools
+
 # Python3 and packages
 RUN dnf install -y python3 python3-pip python3-bugzilla \
     python3-koji python3-requests \

--- a/news/PR472.dev
+++ b/news/PR472.dev
@@ -1,0 +1,1 @@
+Add missing packages to podman dev environment


### PR DESCRIPTION
There were a few required packages missing in container dev environment. This
commit will add them.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>