### PR TITLE
Handle the correct output line for spectool

### DIFF
--- a/hotness/builders/koji.py
+++ b/hotness/builders/koji.py
@@ -292,7 +292,7 @@ class Koji(Builder):
         try:
             output = sp.check_output(["spectool", "-g", specfile_path], cwd=target_dir)
             for line in output.decode("utf-8").splitlines():
-                if line.startswith("Getting"):
+                if line.startswith("Downloaded"):
                     files.append(
                         os.path.realpath(os.path.join(target_dir, line.split()[-1]))
                     )

--- a/news/PR473.bug
+++ b/news/PR473.bug
@@ -1,0 +1,1 @@
+Fix the parsing of spectool output to handle the correct lines

--- a/tests/builders/test_koji.py
+++ b/tests/builders/test_koji.py
@@ -145,7 +145,7 @@ class TestKojiBuild:
             "git clone",
             "rpmdev-bumpspec",
             b"Downloading Lectitio_Divinitatus",
-            b"Getting Codex_Astartes",
+            b"Downloaded: Codex_Astartes",
             b"rpmbuild foobar.srpm",
             "git config",
             "git config",
@@ -269,7 +269,7 @@ class TestKojiBuild:
             "git clone",
             "rpmdev-bumpspec",
             (b"Fake line\n" b"Downloading Lectitio_Divinitatus"),
-            b"Getting Lectitio_Divinitatus",
+            b"Downloaded: Lectitio_Divinitatus",
             b"rpmbuild foobar.srpm",
             "git config",
             "git config",
@@ -329,7 +329,7 @@ class TestKojiBuild:
             "git clone",
             "rpmdev-bumpspec",
             (b"Fake line\n" b"Downloading Lectitio_Divinitatus\n"),
-            b"Getting Lectitio_Divinitatus\nGetting Lectitio_Divinitatus\n",
+            b"Downloaded: Lectitio_Divinitatus\nDownloaded: Lectitio_Divinitatus\n",
             b"rpmbuild foobar.srpm",
             "git config",
             "git config",
@@ -384,7 +384,7 @@ class TestKojiBuild:
             "git clone",
             "rpmdev-bumpspec",
             b"Downloading Lectitio_Divinitatus",
-            b"Getting Lectitio_Divinitatus",
+            b"Downloaded: Lectitio_Divinitatus",
             b"rpmbuild foobar.srpm",
         ]
 
@@ -683,7 +683,7 @@ class TestKojiBuild:
             "git clone",
             "rpmdev-bumpspec",
             (b"Fake line\n" b"Downloading Lectitio_Divinitatus\n"),
-            b"Getting Lectitio_Divinitatus\n",
+            b"Downloaded: Lectitio_Divinitatus\n",
             CalledProcessError(
                 1, "rpmdevbuild", output=b"Some output", stderr=b"Failed miserably"
             ),
@@ -728,7 +728,7 @@ class TestKojiBuild:
             "git clone",
             "rpmdev-bumpspec",
             (b"Fake line\n" b"Downloading Lectitio_Divinitatus\n"),
-            b"Getting Lectitio_Divinitatus\n",
+            b"Downloaded: Lectitio_Divinitatus\n",
             b"rpmbuild foobar.srpm",
             "git config",
             "git config",


### PR DESCRIPTION
The spectool output is now changed to
```
Downloading: https://www.imagemagick.org/download/releases/ImageMagick-6.9.12-51.tar.xz
100% of   8.7 MiB |####################################################################################################################################################################################| Elapsed Time: 0:02:30 Time:  0:02:30
Downloaded: ImageMagick-6.9.12-51.tar.xz
```
Which caused that the comparing of sources were done incorrectly.
This patch fixes that behavior.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>