### PR TITLE
Migrate from dependabot to renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,13 +4,13 @@ queue_rules:
       - check-success=fedora/check
 
 pull_request_rules:
-  - name: dependabot
+  - name: renovatebot
     actions:
       queue:
         method: rebase
         name: default
     conditions:
-    - author=dependabot[bot]
+    - author=renovate[bot]
     - label!=no-mergify
     - "#changes-requested-reviews-by=0"
     - check-success=fedora/check

--- a/news/PR516.other
+++ b/news/PR516.other
@@ -1,0 +1,1 @@
+Migrate from dependabot to renovate

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+      "config:base",
+      "group:allNonMajor",
+      "schedule:weekdays",
+      ":preserveSemverRanges"
   ]
 }


### PR DESCRIPTION
The renovate looks like a better alternative to dependabot, which is no longer actively maintained.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>