### PR TITLE
Fix the documentation build on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,4 +22,4 @@ build:
     post_install:
       - pip install poetry
       - poetry config virtualenvs.create false
-      - poetry install
+      - poetry install --only dev


### PR DESCRIPTION
The readthedocs build environment has problem to handle all the dependencies, so let's install just the development ones as we did before moving to poetry.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>