### PR TITLE
Fix krb_login error

### DIFF
--- a/hotness/builders/koji.py
+++ b/hotness/builders/koji.py
@@ -419,7 +419,7 @@ class Koji(Builder):
         _logger.info("Creating a new Koji session to %s", self.server_url)
         with _koji_session_lock:
             koji_session = koji.ClientSession(self.server_url, self.krb_sessionopts)
-            result = koji_session.krb_login(
+            result = koji_session.gssapi_login(
                 principal=self.krb_principal,
                 keytab=self.krb_keytab,
                 ccache=self.krb_ccache,

--- a/news/549.bug
+++ b/news/549.bug
@@ -1,0 +1,1 @@
+GenericError: Invalid method: krb_login

--- a/tests/builders/test_koji.py
+++ b/tests/builders/test_koji.py
@@ -137,7 +137,7 @@ class TestKojiBuild:
             f.write("This is a patch")
         mock_session = mock.Mock()
         mock_session.build.return_value = 1000
-        mock_session.krb_login.return_value = True
+        mock_session.gssapi_login.return_value = True
         mock_koji.ClientSession.return_value = mock_session
         mock_temp_dir.return_value.__enter__.return_value = tmpdir
 
@@ -170,7 +170,7 @@ class TestKojiBuild:
         mock_koji.ClientSession.assert_called_with(
             self.builder.server_url, self.builder.krb_sessionopts
         )
-        mock_session.krb_login.assert_called_with(
+        mock_session.gssapi_login.assert_called_with(
             principal=self.builder.krb_principal,
             keytab=self.builder.krb_keytab,
             ccache=self.builder.krb_ccache,
@@ -261,7 +261,7 @@ class TestKojiBuild:
             f.write("This is a patch")
         mock_session = mock.Mock()
         mock_session.build.return_value = 1000
-        mock_session.krb_login.return_value = True
+        mock_session.gssapi_login.return_value = True
         mock_koji.ClientSession.return_value = mock_session
         mock_temp_dir.return_value.__enter__.return_value = tmpdir
 
@@ -321,7 +321,7 @@ class TestKojiBuild:
             f.write("This is a patch")
         mock_session = mock.Mock()
         mock_session.build.return_value = 1000
-        mock_session.krb_login.return_value = True
+        mock_session.gssapi_login.return_value = True
         mock_koji.ClientSession.return_value = mock_session
         mock_temp_dir.return_value.__enter__.return_value = tmpdir
 
@@ -376,7 +376,7 @@ class TestKojiBuild:
             f.write("The Emperor is God")
 
         mock_session = mock.Mock()
-        mock_session.krb_login.return_value = None
+        mock_session.gssapi_login.return_value = None
         mock_koji.ClientSession.return_value = mock_session
         mock_temp_dir.return_value.__enter__.return_value = tmpdir
 
@@ -720,7 +720,7 @@ class TestKojiBuild:
 
         mock_session = mock.Mock()
         mock_session.build.return_value = 1000
-        mock_session.krb_login.return_value = True
+        mock_session.gssapi_login.return_value = True
         mock_koji.ClientSession.return_value = mock_session
         mock_temp_dir.return_value.__enter__.return_value = tmpdir
 


### PR DESCRIPTION
Koji library removed krb_login method [3 months
ago](https://pagure.io/koji/c/21c8c0f68125a2ef5385fd99efc0150e29b1c704?branch=master) and left gssapi_login method instead. Unfortunately this caused hotness to start failing on scratch builds.

Fixes #549

Signed-off-by: Michal Konečný <mkonecny@redhat.com>