### PR TITLE
Don't change title of the bugzilla ticket when version is not latest

### DIFF
--- a/hotness/hotness_consumer.py
+++ b/hotness/hotness_consumer.py
@@ -624,19 +624,11 @@ class HotnessConsumer(object):
             projectid=project_id,
             dist_git_url=dist_git_url,
         )
-        if len(retrieved_versions) > 1:
-            if latest_upstream in retrieved_versions:
-                short_desc = self.short_desc_template % dict(
-                    name=package.name, retrieved_version=latest_upstream
-                )
-            else:
-                short_desc = self.short_desc_template_more_versions % dict(
-                    name=package.name
-                )
-        elif retrieved_versions:
-            short_desc = self.short_desc_template % dict(
-                name=package.name, retrieved_version=retrieved_versions[0]
-            )
+        # Don't change the title of bug if the new version received is
+        # older than the latest upstream
+        short_desc = self.short_desc_template % dict(
+            name=package.name, retrieved_version=latest_upstream
+        )
         notify_request = NotifyRequest(
             package=package,
             message=description,

--- a/news/533.bug
+++ b/news/533.bug
@@ -1,0 +1,1 @@
+Bug title being rewritten when older version is obtained by Anitya and not packaged in Fedora yet

--- a/tests/test_hotness_consumer.py
+++ b/tests/test_hotness_consumer.py
@@ -415,9 +415,9 @@ class TestHotnessConsumerCall:
     @pytest.mark.parametrize(
         "test_input,expected",
         [
-            (["0.99.3"], "flatpak-0.99.3 is available"),
+            (["0.99.3"], "flatpak-1.0.4 is available"),
             (["1.0.4"], "flatpak-1.0.4 is available"),
-            (["1.0.3", "0.99.3"], "New versions of flatpak available."),
+            (["1.0.3", "0.99.3"], "flatpak-1.0.4 is available"),
         ],
     )
     def test_bugzilla_notify_with_retrieved_versions(self, test_input, expected):
@@ -426,6 +426,8 @@ class TestHotnessConsumerCall:
             - retrieved_versions and not package.version
             - in case package.version is in retrieved_versions use package.version
             - in case of more than one item in retrieved_versions use generic message.
+            - in case the latest upstream is newer than the retrieved version don't
+              update the header
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         message.body["message"]["upstream_versions"] = test_input


### PR DESCRIPTION
Previously we changed the bugzilla ticket title when we received a new version from Anitya, but this doesn't need to be the latest upstream version all of the time. So it's better to keep the latest upstream in title instead.

Fixes #533