### PR TITLE
Attach spec file diff when DownloadException is raised

### DIFF
--- a/hotness/builders/koji.py
+++ b/hotness/builders/koji.py
@@ -198,7 +198,11 @@ class Koji(Builder):
             # use macros in the source URL(s). We want to detect these and notify
             # the packager on the bug we filed about the new version.
             old_sources = self._dist_git_sources(tmp)
-            new_sources = self._spec_sources(specfile, tmp)
+            try:
+                new_sources = self._spec_sources(specfile, tmp)
+            except DownloadException as exc:
+                # Attach the patch if DownloadException is thrown
+                raise BuilderException(str(exc), value=output)
             output["message"] = self._compare_sources(old_sources, new_sources)
 
             try:
@@ -262,9 +266,6 @@ class Koji(Builder):
 
         Returns:
             A list of absolute paths to source files downloaded
-
-        Raises:
-            subprocess.CalledProcessError: When downloading the sources fails.
         """
         files = []
         # The output format is:

--- a/news/564.bug
+++ b/news/564.bug
@@ -1,0 +1,1 @@
+Spec file diff not attached when `DownloadException` is thrown

--- a/tests/builders/test_koji.py
+++ b/tests/builders/test_koji.py
@@ -21,7 +21,7 @@ from subprocess import CalledProcessError
 from unittest import mock
 
 from hotness.domain import Package
-from hotness.exceptions import DownloadException, BuilderException
+from hotness.exceptions import BuilderException
 from hotness.builders import Koji
 
 
@@ -567,12 +567,16 @@ class TestKojiBuild:
         package = Package(name="test", version="1.0", distro="Fedora")
         opts = {"bz_id": 100}
 
-        with pytest.raises(DownloadException) as exc:
+        with pytest.raises(BuilderException) as exc:
             self.builder.build(package, opts)
 
         assert exc.value.message == (
             "There is a syntax error in updated specfile. "
             "See attached diff for the changes."
+        )
+        assert exc.value.value["patch"] == "The Emperor is God"
+        assert exc.value.value["patch_filename"] == os.path.join(
+            tmpdir, "Lectitio_Divinitatus"
         )
 
     @mock.patch("hotness.builders.koji.sp.check_output")
@@ -606,11 +610,15 @@ class TestKojiBuild:
         package = Package(name="test", version="1.0", distro="Fedora")
         opts = {"bz_id": 100}
 
-        with pytest.raises(DownloadException) as exc:
+        with pytest.raises(BuilderException) as exc:
             self.builder.build(package, opts)
 
         assert exc.value.message == (
             "Unable to resolve the hostname for one of the package's Source URLs"
+        )
+        assert exc.value.value["patch"] == "The Emperor is God"
+        assert exc.value.value["patch_filename"] == os.path.join(
+            tmpdir, "Lectitio_Divinitatus"
         )
 
     @mock.patch("hotness.builders.koji.sp.check_output")
@@ -644,11 +652,15 @@ class TestKojiBuild:
         package = Package(name="test", version="1.0", distro="Fedora")
         opts = {"bz_id": 100}
 
-        with pytest.raises(DownloadException) as exc:
+        with pytest.raises(BuilderException) as exc:
             self.builder.build(package, opts)
 
         assert exc.value.message == (
             "Unable to connect to the host for one of the package's Source URLs"
+        )
+        assert exc.value.value["patch"] == "The Emperor is God"
+        assert exc.value.value["patch_filename"] == os.path.join(
+            tmpdir, "Lectitio_Divinitatus"
         )
 
     @mock.patch("hotness.builders.koji.sp.check_output")
@@ -682,11 +694,15 @@ class TestKojiBuild:
         package = Package(name="test", version="1.0", distro="Fedora")
         opts = {"bz_id": 100}
 
-        with pytest.raises(DownloadException) as exc:
+        with pytest.raises(BuilderException) as exc:
             self.builder.build(package, opts)
 
         assert exc.value.message == (
             "An HTTP error occurred downloading the package's new Source URLs: URL2"
+        )
+        assert exc.value.value["patch"] == "The Emperor is God"
+        assert exc.value.value["patch_filename"] == os.path.join(
+            tmpdir, "Lectitio_Divinitatus"
         )
 
     @mock.patch("hotness.builders.koji.sp.check_output")
@@ -720,12 +736,16 @@ class TestKojiBuild:
         package = Package(name="test", version="1.0", distro="Fedora")
         opts = {"bz_id": 100}
 
-        with pytest.raises(DownloadException) as exc:
+        with pytest.raises(BuilderException) as exc:
             self.builder.build(package, opts)
 
         assert exc.value.message == (
             "Unable to validate the TLS certificate for one of the package's "
             "Source URLs"
+        )
+        assert exc.value.value["patch"] == "The Emperor is God"
+        assert exc.value.value["patch_filename"] == os.path.join(
+            tmpdir, "Lectitio_Divinitatus"
         )
 
     @mock.patch("hotness.builders.koji.sp.check_output")
@@ -759,7 +779,7 @@ class TestKojiBuild:
         package = Package(name="test", version="1.0", distro="Fedora")
         opts = {"bz_id": 100}
 
-        with pytest.raises(DownloadException) as exc:
+        with pytest.raises(BuilderException) as exc:
             self.builder.build(package, opts)
 
         assert exc.value.message == (
@@ -767,6 +787,10 @@ class TestKojiBuild:
             "please report this as a bug on the-new-hotness issue tracker.\n"
             "Error output:\n"
             "None"
+        )
+        assert exc.value.value["patch"] == "The Emperor is God"
+        assert exc.value.value["patch_filename"] == os.path.join(
+            tmpdir, "Lectitio_Divinitatus"
         )
 
     @mock.patch("hotness.builders.koji.sp.check_output")


### PR DESCRIPTION
DownloadException doesn't have any additional values with it, so it doesn't carry the spec file diff that is already created. So let's raise BuilderException instead when DownloadException should be raised.

Fixes #564