### PR TITLE
Add retry when uploading sources to koji

### DIFF
--- a/news/557.bug
+++ b/news/557.bug
@@ -1,0 +1,1 @@
+Retry upload to koji sideload cache when it fails


### PR DESCRIPTION
The koji uploadWrapper sometimes fails with GenericError, let's retry the upload if this happens.

Fixes #557