### PR TITLE
Update minimum python version to 3.8.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8.1"
+python = "^3.8.10"
 anitya-schema = "^2.0.1"
 fedora-messaging = "^3.1.0"
 fedora-messaging-the-new-hotness-schema = "^1.1.2"


### PR DESCRIPTION
diff-cover 8.0.0+ has minimum python requirements 3.8.10, let's update it then.