### PR TITLE
Update dev environment to F40

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
- config.vm.box = "fedora/38-cloud-base"
+ config.vm.box = "fedora/40-cloud-base"
 
  # Forward traffic on the host to the development server on the guest
  # RabbitMQ

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Containerfile.dev
       args:
-        FEDORA_VERSION: 38
+        FEDORA_VERSION: 40
     container_name: "hotness"
     volumes:
       - ./hotness/:/app/hotness:z


### PR DESCRIPTION
As Fedora 38 is EOL, let's update dev environment to F40.
- Updates container deployment
- Updates vagrant deployment