### PR TITLE
Add rhbz prefix in changelog update message

### DIFF
--- a/hotness/builders/koji.py
+++ b/hotness/builders/koji.py
@@ -132,7 +132,7 @@ class Koji(Builder):
 
             specfile = os.path.join(tmp, package.name + ".spec")
 
-            comment = "Update to %s (#%d)" % (package.version, bz_id)
+            comment = "Update to %s (rhbz#%d)" % (package.version, bz_id)
 
             # This requires rpmdevtools-8.5 or greater
             cmd = [


### PR DESCRIPTION
With this prefix, bodhi automatically links the bug to the update and closes the bug accordingly.