### PR TITLE
Fix issue #605: Handle 'nothing to commit' error gracefully

### DIFF
--- a/tests/builders/test_koji_fix_605.py
+++ b/tests/builders/test_koji_fix_605.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""Unit tests for the fix for issue #605 - handling when git repo is already up to date."""
+
+import os
+from unittest import mock
+import pytest
+
+from hotness.builders.koji import Koji
+from hotness.domain.package import Package
+
+
+class TestKojiFix605:
+    """Test the fix for issue #605."""
+
+    def setup_method(self, method):
+        self.builder = Koji(
+            server_url="server_url",
+            web_url="web_url",
+            kerberos_args={
+                "krb_principal": "krb_principal",
+                "krb_keytab": "krb_keytab",
+                "krb_ccache": "krb_ccache",
+                "krb_proxyuser": "krb_proxyuser",
+                "krb_sessionopts": "krb_sessionopts",
+            },
+            git_url="git_url",
+            user_email=("user_name", "user_email"),
+            opts={"opts": "opts"},
+            priority=1,
+            target_tag="target_tag",
+        )
+
+    @mock.patch("hotness.builders.koji.sp.check_output")
+    @mock.patch("hotness.builders.koji.TemporaryDirectory")
+    def test_build_already_up_to_date(self, mock_temp_dir, mock_check_output, tmpdir):
+        """
+        Test that build is skipped when repo is already up to date (git status is clean).
+        This tests the fix for issue #605.
+        """
+        mock_temp_dir.return_value.__enter__.return_value = tmpdir
+
+        # Mock responses including an empty git status (no changes to commit)
+        mock_check_output.side_effect = [
+            "git clone",           # git clone command
+            "rpmdev-bumpspec",     # rpmdev-bumpspec command 
+            "git config",          # git config user.name
+            "git config",          # git config user.email
+            b"",                   # git status --porcelain (empty = no changes)
+        ]
+
+        # Prepare package
+        package = Package(name="test", version="1.0", distro="Fedora")
+        opts = {"bz_id": 100}
+
+        output = self.builder.build(package, opts)
+
+        # Verify that we get the expected output when skipping build
+        assert output == {
+            "build_id": 0,
+            "patch": "",
+            "patch_filename": "",
+            "message": "Package is already up to date in the repository",
+        }
+
+    @mock.patch("hotness.builders.koji.sp.check_output") 
+    @mock.patch("hotness.builders.koji.koji")
+    @mock.patch("hotness.builders.koji.TemporaryDirectory")
+    def test_build_with_changes(self, mock_temp_dir, mock_koji, mock_check_output, tmpdir):
+        """
+        Test that build continues normally when there are changes to commit.
+        """
+        # Create temporary files
+        file = os.path.join(tmpdir, "Lectitio_Divinitatus")
+        with open(file, "w") as f:
+            f.write("The Emperor is God")
+
+        # Mock patch file
+        filename = "patch"
+        file = os.path.join(tmpdir, filename)
+        with open(file, "w") as f:
+            f.write("This is a patch")
+            
+        mock_session = mock.Mock()
+        mock_session.build.return_value = 1000
+        mock_session.gssapi_login.return_value = True
+        mock_koji.ClientSession.return_value = mock_session
+        mock_temp_dir.return_value.__enter__.return_value = tmpdir
+
+        # Mock responses including a non-empty git status (there are changes)
+        mock_check_output.side_effect = [
+            "git clone",                           # git clone command
+            "rpmdev-bumpspec",                     # rpmdev-bumpspec command
+            "git config",                          # git config user.name  
+            "git config",                          # git config user.email
+            b" M test.spec\n",                     # git status --porcelain (has changes)
+            "git commit",                          # git commit command
+            filename.encode(),                     # git format-patch command
+            b"Downloading Lectitio_Divinitatus",   # fedpkg sources
+            b"Downloaded: Lectitio_Divinitatus",   # spectool command
+            b"Wrote: foobar.srpm",                 # rpmbuild command
+        ]
+
+        # Prepare package
+        package = Package(name="test", version="1.0", distro="Fedora")
+        opts = {"bz_id": 100}
+
+        output = self.builder.build(package, opts)
+
+        # Verify that build continues normally
+        assert output["build_id"] == 1000
+        assert output["patch"] == "This is a patch"
+        assert output["patch_filename"] == filename
+        # message field may contain source comparison info, just check it exists
+        assert "message" in output
+
+    @mock.patch("hotness.builders.koji.sp.check_output")
+    @mock.patch("hotness.builders.koji.TemporaryDirectory")
+    def test_build_git_status_fails(self, mock_temp_dir, mock_check_output, tmpdir):
+        """
+        Test that build continues normally if git status command fails.
+        """
+        from subprocess import CalledProcessError
+        
+        mock_temp_dir.return_value.__enter__.return_value = tmpdir
+
+        # Mock git status to raise an exception, then normal flow should continue
+        mock_check_output.side_effect = [
+            "git clone",                                        # git clone command
+            "rpmdev-bumpspec",                                  # rpmdev-bumpspec command 
+            "git config",                                       # git config user.name
+            "git config",                                       # git config user.email
+            CalledProcessError(1, "git status"),               # git status fails
+            CalledProcessError(1, "git commit"),               # git commit fails (normal test flow)
+        ]
+
+        # Prepare package
+        package = Package(name="test", version="1.0", distro="Fedora")
+        opts = {"bz_id": 100}
+
+        # Should raise BuilderException due to git commit failure
+        from hotness.exceptions import BuilderException
+        with pytest.raises(BuilderException):
+            self.builder.build(package, opts)


### PR DESCRIPTION
This PR fixes the crash reported in #605 where the git commit command fails with exit code 1 when the repository is already up to date (i.e., rpmdev-bumpspec makes no changes to the spec file).

Changes Proposed:

Added Pre-commit Check: Implemented a check using git status --porcelain before attempting to commit.

If the working tree is clean, the build process now logs an info message ("Repo ... is already up to date") and returns early with a status of "skipped".

This prevents the BuilderException caused by git commit failing when there is nothing to commit.

Robust Source Comparison: Updated the _compare_sources method to check if a file exists before attempting to open it. This addresses the secondary FileNotFoundError reported in the issue comments (by @lrineau) regarding pkgs repo file access.

New Tests: Added tests/builders/test_koji_fix_605.py to verify:

The build is skipped gracefully when the repo is clean.

The build proceeds normally when changes exist.

Exceptions during git status are handled correctly.

related issue
Fixes #605

How to test
Run the new test suite to verify the fix:

Bash

poetry run pytest tests/builders/test_koji_fix_605.py
Or run the full suite:

Bash

tox -e py313