### PR TITLE
fix: Update black target-version to match minimum Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ template = "news/_template.rst"
 
 [tool.black]
 line-length = 88
-target-version = ['py36']
+target-version = ['py311']
 include = '\.pyi?$'
 exclude = '''
 (


### PR DESCRIPTION
The project requires Python 3.11+ but black was configured to target Python 3.6. This updates the black configuration to target py311 to match the minimum supported Python version.