### PR TITLE
docs: Update IRC channel from fedora-fedmsg to fedora-apps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,9 +22,8 @@ To see recent messages from the-new-hotness:
 * Check Fedora's `datagrepper
   <https://apps.fedoraproject.org/datagrepper/raw?category=hotness&delta=2592000>`_
 
-* Or join #fedora-apps IRC channel on `libera <https://libera.chat/>`_ and watch for ``hotness``
+* Or join the `Fedora Apps room <https://matrix.to/#/#apps:fedoraproject.org>`_ on Matrix and watch for ``hotness``
   messages.
-
 To see recent koji builds started by the-new-hotness:
 
 * Check Fedora's `koji builds

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ To see recent messages from the-new-hotness:
 * Check Fedora's `datagrepper
   <https://apps.fedoraproject.org/datagrepper/raw?category=hotness&delta=2592000>`_
 
-* Or join #fedora-fedmsg IRC channel on `libera <https://libera.chat/>`_ and watch for ``hotness``
+* Or join #fedora-apps IRC channel on `libera <https://libera.chat/>`_ and watch for ``hotness``
   messages.
 
 To see recent koji builds started by the-new-hotness:


### PR DESCRIPTION
## Description
Updates the README to reference the correct IRC channel for Fedora applications.

## Background
The `#fedora-fedmsg` IRC channel is outdated since Fedora infrastructure migrated from fedmsg to fedora-messaging. The current channel for Fedora applications including the-new-hotness is `#fedora-apps`.

## Changes
- Updated IRC channel reference in README.rst from `#fedora-fedmsg` to `#fedora-apps`

## Impact
- Users will now be directed to the correct IRC channel to observe the-new-hotness messages
- Aligns documentation with current Fedora infrastructure