### PR TITLE
Add support for monitoring configuration file

### DIFF
--- a/config/monitoring.toml.example
+++ b/config/monitoring.toml.example
@@ -1,0 +1,13 @@
+# Enable/disable monitoring
+monitoring = false
+# Enable/disable filling bugzilla ticket for new release
+# When disabled it will also disable scratch builds
+bugzilla = true
+# Enable/disable reporting only stable versions
+# Stable versions are recognized based on release-monitoring.org project settings
+stable_only = false
+# Enable/disable reporting all new versions instead of the latest one
+# Enabling this will disable scratch builds
+all_versions = false
+# Enable/disable scratch build for newly opened version
+scratch_build = false

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -3,9 +3,29 @@ User guide
 
 This chapter describes how the user (packager) can interact with The New Hotness.
 
-
 Notifications settings
 ----------------------
+
+The notifications settings for The New Hotness can be set by creating file
+`monitoring.toml` in `dist git <https://src.fedoraproject.org>`_. If the file
+is missing the legacy settings will be checked (when we move dist-git to forgejo
+the monitoring will be treated as disabled in this case).
+
+.. note::
+   The setting doesn't matter if the project is not created in
+   `Anitya <https://release-monitoring.org>`_.
+
+Following is an example `monitoring.toml` file with default values.
+
+.. include:: ../config/monitoring.toml.example
+   :literal:
+
+Notifications settings (legacy)
+-------------------------------
+
+.. note::
+   This approach will be supported for legacy reasons, but the new approach is
+   preferred as it not depends on hosting platform.
 
 The notifications settings for The New Hotness can be set in the
 `dist git <https://src.fedoraproject.org>`_. The option is available for each
@@ -47,11 +67,6 @@ Following is the explanation of the `Monitoring status` options:
   Hotness and Bugzilla notification will be created each time a new stable version will
   be discovered by Anitya. In case multiple versions are reported at once, newest stable
   will be used. Additionally a scratch build will be started for the new version.
-
-.. note::
-   The *Monitoring all*, *Monitoring all and scratch builds*, *Monitoring stable only*
-   and *Monitoring stable only and scratch builds* options are supported by
-   The New Hotness, but not yet available on `dist git <https://src.fedoraproject.org>`_.
 
 Creating a project in Anitya
 ----------------------------

--- a/hotness/hotness_consumer.py
+++ b/hotness/hotness_consumer.py
@@ -353,8 +353,10 @@ class HotnessConsumer(object):
 
         This handler deals with new versions found by Anitya. A new upstream
         release can map to several downstream packages, so each package in
-        Rawhide (if any) are checked against the newly released version. If
-        they are older than the new version, a bug is filed.
+        Rawhide (if any) are checked against the newly released version.
+
+        It checks the monitoring setting of packager and works with the update
+        according to packager preferences.
 
         Topic: `org.release-monitoring.prod.anitya.project.version.update`
 
@@ -429,6 +431,7 @@ class HotnessConsumer(object):
                     return
 
                 scratch_build = validation_output["scratch_build"]
+                bugzilla = validation_output["bugzilla"]
 
                 current_version = validation_output["version"]
                 current_release = validation_output["release"]
@@ -437,32 +440,38 @@ class HotnessConsumer(object):
                 if validation_output["stable_only"]:
                     retrieved_versions = retrieved_stable_versions
 
-                # Comment on bugzilla
-                bz_id = self._comment_on_bugzilla_with_template(
-                    package=package,
-                    current_version=current_version,
-                    current_release=current_release,
-                    project_homepage=message.project_homepage,
-                    project_id=message.project_id,
-                    retrieved_versions=retrieved_versions,
-                )
-
-                # Failure happened when communicating with bugzilla
-                if bz_id == -1:
-                    opts = {
-                        "body": {
-                            "trigger": {"msg": message.body, "topic": message.topic},
-                            "reason": "bugzilla",
-                        }
-                    }
-
-                    notify_request = NotifyRequest(
-                        package=package, message="update.drop", opts=opts
+                bz_id = -1
+                if bugzilla:
+                    # Comment on bugzilla
+                    bz_id = self._comment_on_bugzilla_with_template(
+                        package=package,
+                        current_version=current_version,
+                        current_release=current_release,
+                        project_homepage=message.project_homepage,
+                        project_id=message.project_id,
+                        retrieved_versions=retrieved_versions,
                     )
-                    fedora_messaging_use_case.notify(notify_request)
-                    return
+
+                    # Failure happened when communicating with bugzilla
+                    if bz_id == -1:
+                        opts = {
+                            "body": {
+                                "trigger": {
+                                    "msg": message.body,
+                                    "topic": message.topic,
+                                },
+                                "reason": "bugzilla",
+                            }
+                        }
+
+                        notify_request = NotifyRequest(
+                            package=package, message="update.drop", opts=opts
+                        )
+                        fedora_messaging_use_case.notify(notify_request)
+                        return
 
                 # Send Fedora messaging notification
+                # This will have bz_id = -1 if there isn't any bugzilla ticket filled
                 opts = {
                     "body": {
                         "trigger": {"msg": message.body, "topic": message.topic},
@@ -477,7 +486,7 @@ class HotnessConsumer(object):
                 fedora_messaging_use_case.notify(notify_request)
 
                 # Do a scratch build
-                if scratch_build:
+                if scratch_build and bugzilla:
                     self._handle_scratch_build(package, bz_id)
 
     def _validate_package(self, package: Package, stable_versions: List[str]) -> dict:
@@ -497,6 +506,8 @@ class HotnessConsumer(object):
             Dictionary containing output from the validators.
             Example:
             {
+                # Fill in the bugzilla issue
+                "bugzilla": True,
                 # Monitoring setting for scratch build
                 "scratch_build": True,
                 # Monitoring setting for stable versions
@@ -510,6 +521,7 @@ class HotnessConsumer(object):
             }
         """
         output = {
+            "bugzilla": True,
             "scratch_build": False,
             "stable_only": False,
             "version": "",
@@ -536,6 +548,7 @@ class HotnessConsumer(object):
             output["reason"] = "monitoring settings"
             return output
 
+        output["bugzilla"] = response.value["bugzilla"]
         output["scratch_build"] = response.value["scratch_build"]
         output["stable_only"] = response.value["stable_only"]
         all_versions = response.value["all_versions"]

--- a/hotness/validators/pagure.py
+++ b/hotness/validators/pagure.py
@@ -16,6 +16,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import logging
+import tomllib as toml
 from typing import Optional, Tuple, Union
 
 from . import Validator
@@ -90,6 +91,7 @@ class Pagure(Validator):
             Example:
             {
                 "monitoring": True,  # If the packager wants to be notified or not
+                "bugzilla": True, # If the packager wants bugzilla tickets to be filled
                 "all_versions": True,  # If the packager wants to be notified about every
                                        # version received by Anitya
                 "stable_only": True,  # If the packager wants to be notified only about
@@ -103,59 +105,12 @@ class Pagure(Validator):
         """
         output = {
             "monitoring": False,
+            "bugzilla": True,
             "scratch_build": False,
             "stable_only": False,
             "all_versions": False,
+            "retired": False,
         }
-        dist_git_url = "{0}/_dg/anitya/rpms/{1}".format(self.url, package.name)
-        _logger.debug(
-            "Checking {} to see if {} is monitored.".format(dist_git_url, package.name)
-        )
-        response = self.requests_session.get(dist_git_url, timeout=self.timeout)
-
-        if not response.status_code == 200:
-            raise HTTPException(
-                response.status_code,
-                "Error encountered on request {}".format(dist_git_url),
-            )
-        data = response.json()
-        monitoring_value = data.get("monitoring", "no-monitoring")
-
-        # Fill the output based on the monitoring value
-        # Invalid = monitoring: False; scrach_build: False; all_versions: False; stable_only: False
-        # monitoring =
-        #   monitoring: True; scrach_build: False; all_versions: False; stable_only: False
-        # monitoring-with-scratch =
-        #   monitoring: True; scrach_build: True; all_versions: False; stable_only: False
-        # monitoring-all =
-        #   monitoring: True; scrach_build: False; all_versions: True; stable_only: False
-        # monitoring-all-scratch =
-        #   monitoring: True; scrach_build: True; all_versions: True; stable_only: False
-        # monitoring-stable =
-        #   monitoring: True; scrach_build: False; all_versions: True; stable_only: True
-        # monitoring-stable-scratch =
-        #   monitoring: True; scrach_build: True; all_versions: True; stable_only: True
-        # no-monitoring =
-        #   monitoring: False; scrach_build: False; all_versions: False; stable_only: False
-        if monitoring_value not in MONITORING_STATUSES:
-            _logger.info(
-                "Unknown status '{}' recovered from {}".format(
-                    dist_git_url, monitoring_value
-                )
-            )
-
-        if monitoring_value.startswith("monitoring"):
-            output["monitoring"] = True
-
-        if monitoring_value.startswith("monitoring-all"):
-            output["all_versions"] = True
-
-        if monitoring_value.startswith("monitoring-stable"):
-            output["stable_only"] = True
-
-        if monitoring_value in MONITORING_STATUSES_SCRATCH_BUILD:
-            output["scratch_build"] = True
-
         # Check if the package is retired
         dead_package_url = "{0}/rpms/{1}/blob/{2}/f/dead.package".format(
             self.url, package.name, self.branch
@@ -166,7 +121,7 @@ class Pagure(Validator):
             ("type", self.package_type),
             ("active", True),
         )
-        ""
+
         _logger.debug(
             "Checking {} to see if {} is retired, {}".format(
                 dead_package_url, package, params
@@ -182,5 +137,82 @@ class Pagure(Validator):
 
         # If there is dead.package found, package is retired
         output["retired"] = response.status_code == 200
+
+        # Only check monitoring if the package is not retired
+        if not output["retired"]:
+            # Check for monitoring config file in repository first
+            monitoring_config_url = "{0}/rpms/{1}/raw/{2}/f/monitoring.toml".format(
+                self.url, package.name, self.branch
+            )
+            _logger.debug(
+                "Checking {} to see if {} is using monitoring config".format(
+                    monitoring_config_url, package
+                )
+            )
+            response = self.requests_session.get(
+                monitoring_config_url, timeout=self.timeout
+            )
+
+            if response.status_code == 200:
+                config = toml.loads(response.text)
+                output["monitoring"] = config.get("monitoring", True)
+                output["bugzilla"] = config.get("bugzilla", True)
+                output["all_versions"] = config.get("all_versions", False)
+                output["stable_only"] = config.get("stable_only", False)
+                output["scratch_build"] = config.get("scratch_build", False)
+
+            # If the configuration file is not available check the old monitoring setting
+            else:
+                dist_git_url = "{0}/_dg/anitya/rpms/{1}".format(self.url, package.name)
+                _logger.debug(
+                    "Checking {} to see if {} is monitored.".format(
+                        dist_git_url, package.name
+                    )
+                )
+                response = self.requests_session.get(dist_git_url, timeout=self.timeout)
+
+                if not response.status_code == 200:
+                    raise HTTPException(
+                        response.status_code,
+                        "Error encountered on request {}".format(dist_git_url),
+                    )
+                data = response.json()
+                monitoring_value = data.get("monitoring", "no-monitoring")
+
+                # Fill the output based on the monitoring value
+                # Invalid =
+                #   monitoring: False; scrach_build: False; all_versions: False; stable_only: False
+                # monitoring =
+                #   monitoring: True; scrach_build: False; all_versions: False; stable_only: False
+                # monitoring-with-scratch =
+                #   monitoring: True; scrach_build: True; all_versions: False; stable_only: False
+                # monitoring-all =
+                #   monitoring: True; scrach_build: False; all_versions: True; stable_only: False
+                # monitoring-all-scratch =
+                #   monitoring: True; scrach_build: True; all_versions: True; stable_only: False
+                # monitoring-stable =
+                #   monitoring: True; scrach_build: False; all_versions: True; stable_only: True
+                # monitoring-stable-scratch =
+                #   monitoring: True; scrach_build: True; all_versions: True; stable_only: True
+                # no-monitoring =
+                #   monitoring: False; scrach_build: False; all_versions: False; stable_only: False
+                if monitoring_value not in MONITORING_STATUSES:
+                    _logger.info(
+                        "Unknown status '{}' recovered from {}".format(
+                            dist_git_url, monitoring_value
+                        )
+                    )
+
+                if monitoring_value.startswith("monitoring"):
+                    output["monitoring"] = True
+
+                if monitoring_value.startswith("monitoring-all"):
+                    output["all_versions"] = True
+
+                if monitoring_value.startswith("monitoring-stable"):
+                    output["stable_only"] = True
+
+                if monitoring_value in MONITORING_STATUSES_SCRATCH_BUILD:
+                    output["scratch_build"] = True
 
         return output

--- a/news/628.feature
+++ b/news/628.feature
@@ -1,0 +1,1 @@
+Support monitoring config in dist-git repository

--- a/tests/test_hotness_consumer.py
+++ b/tests/test_hotness_consumer.py
@@ -263,6 +263,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": False,
@@ -332,6 +333,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": True,
             "stable_only": False,
@@ -402,6 +404,7 @@ class TestHotnessConsumerCall:
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         message.body["message"]["upstream_versions"] = test_input
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": True,
             "stable_only": False,
@@ -457,6 +460,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": True,
             "stable_only": False,
@@ -517,6 +521,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": True,
             "stable_only": False,
@@ -587,6 +592,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": True,
@@ -657,6 +663,7 @@ class TestHotnessConsumerCall:
             "anitya.project.version.update.v2", "fedora_mapping_stable_multiple"
         )
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": True,
@@ -727,6 +734,7 @@ class TestHotnessConsumerCall:
             "anitya.project.version.update.v2", "fedora_mapping_no_stable"
         )
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": True,
@@ -762,6 +770,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": False,
@@ -842,6 +851,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": False,
@@ -928,6 +938,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": False,
@@ -1000,6 +1011,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": False,
@@ -1094,6 +1106,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": False,
             "all_versions": False,
             "stable_only": False,
@@ -1124,6 +1137,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": False,
@@ -1205,6 +1219,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": False,
@@ -1235,6 +1250,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": False,
@@ -1265,6 +1281,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": False,
@@ -1301,6 +1318,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": False,
@@ -1333,6 +1351,7 @@ class TestHotnessConsumerCall:
         """
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": True,
             "monitoring": True,
             "all_versions": False,
             "stable_only": False,
@@ -1380,6 +1399,44 @@ class TestHotnessConsumerCall:
 
         self.consumer.notifier_fedora_messaging.notify.assert_called_with(
             package, "update.drop", exp_opts
+        )
+
+    def test_call_anitya_update_no_bugzilla(self):
+        """
+        Assert that update message is handled correctly, when bugzilla is not filled.
+        """
+        message = create_message("anitya.project.version.update.v2", "fedora_mapping")
+        self.consumer.validator_pagure.validate.return_value = {
+            "bugzilla": False,
+            "monitoring": True,
+            "all_versions": False,
+            "stable_only": False,
+            "scratch_build": False,
+            "retired": False,
+        }
+        self.consumer.validator_mdapi.validate.return_value = {
+            "newer": True,
+            "version": "0.16.0",
+            "release": 1,
+        }
+        self.consumer.__call__(message)
+
+        package = Package(name="flatpak", version="1.0.4", distro="Fedora")
+
+        self.consumer.validator_pagure.validate.assert_called_with(package)
+        self.consumer.validator_mdapi.validate.assert_called_with(package)
+        self.consumer.notifier_bugzilla.notify.assert_not_called()
+
+        exp_opts = {
+            "body": {
+                "trigger": {"msg": message.body, "topic": message.topic},
+                "bug": {"bug_id": -1},
+                "package": package.name,
+            }
+        }
+
+        self.consumer.notifier_fedora_messaging.notify.assert_called_with(
+            package, "update.bug.file", exp_opts
         )
 
     #

--- a/tests/validators/test_pagure.py
+++ b/tests/validators/test_pagure.py
@@ -65,17 +65,37 @@ class TestPagureValidate:
 
         self.validator = Pagure(url, requests_session, timeout, branch, package_type)
 
-    def test_validate_monitoring(self):
+    @pytest.mark.parametrize(
+        "monitoring_value",
+        [
+            "monitoring",
+            "no-monitoring",
+            "monitoring-with-scratch",
+            "monitoring-all",
+            "monitoring-all-scratch",
+            "monitoring-stable",
+            "monitoring-stable-scratch",
+        ],
+    )
+    def test_validate_monitoring(self, monitoring_value):
         """
         Assert that validation returns correct output when monitoring is set.
         """
         # Mock requests_session
-        response = mock.Mock()
-        response.status_code = 200
-        response.json.return_value = {
-            "monitoring": "monitoring",
+        response_retired = mock.Mock()
+        response_retired.status_code = 404
+        response_config = mock.Mock()
+        response_config.status_code = 404
+        response_monitoring_setting = mock.Mock()
+        response_monitoring_setting.status_code = 200
+        response_monitoring_setting.json.return_value = {
+            "monitoring": monitoring_value,
         }
-        self.validator.requests_session.get.return_value = response
+        self.validator.requests_session.get.side_effect = [
+            response_retired,
+            response_config,
+            response_monitoring_setting,
+        ]
 
         # Prepare package
         package = Package(name="test", version="1.1", distro="Fedora")
@@ -84,11 +104,6 @@ class TestPagureValidate:
 
         # Parameters for requests get call
         timeout = (5, 20)
-
-        self.validator.requests_session.get.assert_any_call(
-            self.validator.url + "/_dg/anitya/rpms/{}".format(package.name),
-            timeout=timeout,
-        )
 
         self.validator.requests_session.get.assert_any_call(
             self.validator.url
@@ -100,207 +115,59 @@ class TestPagureValidate:
             timeout=timeout,
         )
 
-        assert 2 == self.validator.requests_session.get.call_count
-
-        assert result["monitoring"] is True
-        assert result["all_versions"] is False
-        assert result["stable_only"] is False
-        assert result["scratch_build"] is False
-        assert result["retired"] is True
-
-    def test_validate_no_monitoring(self):
-        """
-        Assert that validation returns correct output when monitoring is not set.
-        """
-        # Mock requests_session
-        response = mock.Mock()
-        response.status_code = 200
-        response.json.return_value = {
-            "monitoring": "no-monitoring",
-        }
-        self.validator.requests_session.get.return_value = response
-
-        # Prepare package
-        package = Package(name="test", version="1.1", distro="Fedora")
-
-        result = self.validator.validate(package)
-
-        # Parameters for requests get call
-        timeout = (5, 20)
-
         self.validator.requests_session.get.assert_any_call(
             self.validator.url + "/_dg/anitya/rpms/{}".format(package.name),
             timeout=timeout,
         )
 
-        assert result["monitoring"] is False
-        assert result["all_versions"] is False
-        assert result["stable_only"] is False
-        assert result["scratch_build"] is False
-
-    def test_validate_monitoring_scratch(self):
-        """
-        Assert that validation returns correct output when monitoring with scratch build is set.
-        """
-        # Mock requests_session
-        response = mock.Mock()
-        response.status_code = 200
-        response.json.return_value = {
-            "monitoring": "monitoring-with-scratch",
-        }
-        self.validator.requests_session.get.return_value = response
-
-        # Prepare package
-        package = Package(name="test", version="1.1", distro="Fedora")
-
-        result = self.validator.validate(package)
-
-        # Parameters for requests get call
-        timeout = (5, 20)
-
         self.validator.requests_session.get.assert_any_call(
-            self.validator.url + "/_dg/anitya/rpms/{}".format(package.name),
+            self.validator.url
+            + "/rpms/"
+            + package.name
+            + "/raw/"
+            + self.validator.branch
+            + "/f/monitoring.toml",
             timeout=timeout,
         )
 
-        assert result["monitoring"] is True
-        assert result["all_versions"] is False
-        assert result["stable_only"] is False
-        assert result["scratch_build"] is True
+        assert 3 == self.validator.requests_session.get.call_count
 
-    def test_validate_monitoring_all(self):
-        """
-        Assert that validation returns correct output when monitoring for all versions
-        is set.
-        """
-        # Mock requests_session
-        response = mock.Mock()
-        response.status_code = 200
-        response.json.return_value = {
-            "monitoring": "monitoring-all",
-        }
-        self.validator.requests_session.get.return_value = response
-
-        # Prepare package
-        package = Package(name="test", version="1.1", distro="Fedora")
-
-        result = self.validator.validate(package)
-
-        # Parameters for requests get call
-        timeout = (5, 20)
-
-        self.validator.requests_session.get.assert_any_call(
-            self.validator.url + "/_dg/anitya/rpms/{}".format(package.name),
-            timeout=timeout,
-        )
-
-        assert result["monitoring"] is True
-        assert result["all_versions"] is True
-        assert result["stable_only"] is False
-        assert result["scratch_build"] is False
-
-    def test_validate_monitoring_all_scratch(self):
-        """
-        Assert that validation returns correct output when monitoring for all versions
-        with scratch build is set.
-        """
-        # Mock requests_session
-        response = mock.Mock()
-        response.status_code = 200
-        response.json.return_value = {
-            "monitoring": "monitoring-all-scratch",
-        }
-        self.validator.requests_session.get.return_value = response
-
-        # Prepare package
-        package = Package(name="test", version="1.1", distro="Fedora")
-
-        result = self.validator.validate(package)
-
-        # Parameters for requests get call
-        timeout = (5, 20)
-
-        self.validator.requests_session.get.assert_any_call(
-            self.validator.url + "/_dg/anitya/rpms/{}".format(package.name),
-            timeout=timeout,
-        )
-
-        assert result["monitoring"] is True
-        assert result["all_versions"] is True
-        assert result["stable_only"] is False
-        assert result["scratch_build"] is True
-
-    def test_validate_monitoring_stable(self):
-        """
-        Assert that validation returns correct output when monitoring for stable versions
-        is set.
-        """
-        # Mock requests_session
-        response = mock.Mock()
-        response.status_code = 200
-        response.json.return_value = {
-            "monitoring": "monitoring-stable",
-        }
-        self.validator.requests_session.get.return_value = response
-
-        # Prepare package
-        package = Package(name="test", version="1.1", distro="Fedora")
-
-        result = self.validator.validate(package)
-
-        # Parameters for requests get call
-        timeout = (5, 20)
-
-        self.validator.requests_session.get.assert_any_call(
-            self.validator.url + "/_dg/anitya/rpms/{}".format(package.name),
-            timeout=timeout,
-        )
-
-        assert result["monitoring"] is True
-        assert result["all_versions"] is False
-        assert result["stable_only"] is True
-        assert result["scratch_build"] is False
-
-    def test_validate_monitoring_stable_scratch(self):
-        """
-        Assert that validation returns correct output when monitoring for stable versions
-        with scratch build is set.
-        """
-        # Mock requests_session
-        response = mock.Mock()
-        response.status_code = 200
-        response.json.return_value = {
-            "monitoring": "monitoring-stable-scratch",
-        }
-        self.validator.requests_session.get.return_value = response
-
-        # Prepare package
-        package = Package(name="test", version="1.1", distro="Fedora")
-
-        result = self.validator.validate(package)
-
-        # Parameters for requests get call
-        timeout = (5, 20)
-
-        self.validator.requests_session.get.assert_any_call(
-            self.validator.url + "/_dg/anitya/rpms/{}".format(package.name),
-            timeout=timeout,
-        )
-
-        assert result["monitoring"] is True
-        assert result["all_versions"] is False
-        assert result["stable_only"] is True
-        assert result["scratch_build"] is True
+        if monitoring_value != "no-monitoring":
+            assert result["monitoring"] is True
+        else:
+            assert result["monitoring"] is False
+        assert result["bugzilla"] is True
+        if monitoring_value.startswith("monitoring-all"):
+            assert result["all_versions"] is True
+        else:
+            assert result["all_versions"] is False
+        if monitoring_value.startswith("monitoring-stable"):
+            assert result["stable_only"] is True
+        else:
+            assert result["stable_only"] is False
+        if "scratch" in monitoring_value:
+            assert result["scratch_build"] is True
+        else:
+            assert result["scratch_build"] is False
+        assert result["retired"] is False
 
     def test_validate_monitoring_is_missing(self):
         """
         Assert that validation returns correct output when monitoring option is missing.
         """
         # Mock requests_session
-        response = mock.Mock()
-        response.status_code = 200
-        response.json.return_value = {}
-        self.validator.requests_session.get.return_value = response
+        response_retired = mock.Mock()
+        response_retired.status_code = 404
+        response_config = mock.Mock()
+        response_config.status_code = 404
+        response_monitoring_setting = mock.Mock()
+        response_monitoring_setting.status_code = 200
+        response_monitoring_setting.json.return_value = {}
+        self.validator.requests_session.get.side_effect = [
+            response_retired,
+            response_config,
+            response_monitoring_setting,
+        ]
 
         # Prepare package
         package = Package(name="test", version="1.1", distro="Fedora")
@@ -316,21 +183,31 @@ class TestPagureValidate:
         )
 
         assert result["monitoring"] is False
+        assert result["bugzilla"] is True
         assert result["all_versions"] is False
         assert result["stable_only"] is False
         assert result["scratch_build"] is False
+        assert result["retired"] is False
 
     def test_validate_invalid_monitoring_value(self):
         """
         Assert that validation returns correct output when monitoring value is invalid.
         """
         # Mock requests_session
-        response = mock.Mock()
-        response.status_code = 200
-        response.json.return_value = {
+        response_retired = mock.Mock()
+        response_retired.status_code = 404
+        response_config = mock.Mock()
+        response_config.status_code = 404
+        response_monitoring_setting = mock.Mock()
+        response_monitoring_setting.status_code = 200
+        response_monitoring_setting.json.return_value = {
             "monitoring": "foobar",
         }
-        self.validator.requests_session.get.return_value = response
+        self.validator.requests_session.get.side_effect = [
+            response_retired,
+            response_config,
+            response_monitoring_setting,
+        ]
 
         # Prepare package
         package = Package(name="test", version="1.1", distro="Fedora")
@@ -346,19 +223,32 @@ class TestPagureValidate:
         )
 
         assert result["monitoring"] is False
+        assert result["bugzilla"] is True
         assert result["all_versions"] is False
         assert result["stable_only"] is False
         assert result["scratch_build"] is False
+        assert result["retired"] is False
 
     @pytest.mark.parametrize("statuscode", (500, 404))
     def test_validate_response_monitoring_not_ok(self, statuscode):
         """
         Assert that validation raises HTTPException when response code is 500 or 404.
         """
-        response = mock.Mock()
-        response.status_code = statuscode
-
-        self.validator.requests_session.get.return_value = response
+        # Mock requests_session
+        response_retired = mock.Mock()
+        response_retired.status_code = 404
+        response_config = mock.Mock()
+        response_config.status_code = 404
+        response_monitoring_setting = mock.Mock()
+        response_monitoring_setting.status_code = statuscode
+        response_monitoring_setting.json.return_value = {
+            "monitoring": "foobar",
+        }
+        self.validator.requests_session.get.side_effect = [
+            response_retired,
+            response_config,
+            response_monitoring_setting,
+        ]
 
         # Prepare package
         package = Package(name="test", version="1.0", distro="Fedora")
@@ -387,24 +277,18 @@ class TestPagureValidate:
             timeout=timeout,
         )
 
-        assert 1 == self.validator.requests_session.get.call_count
+        assert 3 == self.validator.requests_session.get.call_count
 
-    def test_validate_response_monitoring_ok_retired_not_ok(self):
+    def test_validate_response_retired_not_ok(self):
         """
-        Assert that validation raises HTTPException when response code is 200
-        for the monitoring call, but 500 for the retirement call.
+        Assert that validation raises HTTPException when response code is 500
+        for the retirement call.
         """
-        response = mock.Mock()
-
-        self.validator.requests_session.get.return_value = response
-
         # Prepare package
         package = Package(name="test", version="1.0", distro="Fedora")
-        response200 = mock.Mock()
-        response200.status_code = 200
         response500 = mock.Mock()
         response500.status_code = 500
-        self.validator.requests_session.get.side_effect = [response200, response500]
+        self.validator.requests_session.get.return_value = response500
 
         with pytest.raises(HTTPException) as ex:
             self.validator.validate(package)
@@ -419,48 +303,98 @@ class TestPagureValidate:
         timeout = (5, 20)
         branch = "rawhide"
 
-        self.validator.requests_session.get.assert_any_call(
-            self.validator.url + "/_dg/anitya/rpms/{}".format(package.name),
-            timeout=timeout,
-        )
         self.validator.requests_session.get.assert_called_with(
             self.validator.url
             + "/rpms/{0}/blob/{1}/f/dead.package".format(package.name, branch),
             timeout=timeout,
         )
 
-        assert 2 == self.validator.requests_session.get.call_count
+        assert 1 == self.validator.requests_session.get.call_count
 
-    def test_validate_not_retired(self):
+    def test_validate_retired(self):
         """
         Assert that Pagure returns correct output when package is retired.
         """
-        response = mock.Mock()
-
-        self.validator.requests_session.get.return_value = response
-
         # Prepare package
         package = Package(name="test", version="1.0", distro="Fedora")
         response200 = mock.Mock()
         response200.status_code = 200
-        response404 = mock.Mock()
-        response404.status_code = 404
-        self.validator.requests_session.get.side_effect = [response200, response404]
+        self.validator.requests_session.get.return_value = response200
         result = self.validator.validate(package)
 
         # Parameters for requests get call
         timeout = (5, 20)
         branch = "rawhide"
 
-        self.validator.requests_session.get.assert_any_call(
-            self.validator.url + "/_dg/anitya/rpms/{}".format(package.name),
-            timeout=timeout,
-        )
         self.validator.requests_session.get.assert_called_with(
             self.validator.url
             + "/rpms/{0}/blob/{1}/f/dead.package".format(package.name, branch),
             timeout=timeout,
         )
 
+        assert 1 == self.validator.requests_session.get.call_count
+        assert result["retired"] is True
+
+    @pytest.mark.parametrize(
+        "monitoring_config",
+        [
+            {
+                "monitoring": False,
+                "bugzilla": True,
+                "all_versions": True,
+                "stable_only": True,
+                "scratch_build": True,
+            },
+            {
+                "monitoring": False,
+                "all_versions": True,
+            },
+            {},
+        ],
+    )
+    def test_monitoring_config(self, monitoring_config):
+        """
+        Test that monitoring config is correctly processed.
+        """
+        # Convert monitoring_config dict to toml format
+        toml_str = ""
+        for key, value in monitoring_config.items():
+            toml_str = toml_str + f"{key} = {str(value).lower()}\n"
+
+        # Mock requests_session
+        response_retired = mock.Mock()
+        response_retired.status_code = 404
+        response_config = mock.Mock()
+        response_config.status_code = 200
+        response_config.text = toml_str
+        self.validator.requests_session.get.side_effect = [
+            response_retired,
+            response_config,
+        ]
+
+        # Prepare package
+        package = Package(name="test", version="1.1", distro="Fedora")
+
+        result = self.validator.validate(package)
+
+        # Parameters for requests get call
+        timeout = (5, 20)
+
+        self.validator.requests_session.get.assert_any_call(
+            self.validator.url
+            + "/rpms/"
+            + package.name
+            + "/raw/"
+            + self.validator.branch
+            + "/f/monitoring.toml",
+            timeout=timeout,
+        )
+
         assert 2 == self.validator.requests_session.get.call_count
+
+        assert result["monitoring"] is monitoring_config.get("monitoring", True)
+        assert result["bugzilla"] is monitoring_config.get("bugzilla", True)
+        assert result["all_versions"] is monitoring_config.get("all_versions", False)
+        assert result["stable_only"] is monitoring_config.get("stable_only", False)
+        assert result["scratch_build"] is monitoring_config.get("scratch_build", False)
         assert result["retired"] is False


### PR DESCRIPTION
This will add support for working with configuration file created in dist-git. This file will be monitoring.toml and will be a new way of reading project configuration regarding monitoring. The old way will be supported till we move to forgejo dist-git.

Fixes #628