### PR TITLE
Return message back to queue on bugzilla error

### DIFF
--- a/hotness/exceptions/connection_exception.py
+++ b/hotness/exceptions/connection_exception.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -15,10 +15,24 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-from .base_exception import BaseHotnessException  # noqa: F401
-from .builder_exception import BuilderException  # noqa: F401
-from .connection_exception import ConnectionException  # noqa: F401
-from .download_exception import DownloadException  # noqa: F401
-from .http_exception import HTTPException  # noqa: F401
-from .notifier_exception import NotifierException  # noqa: F401
-from .patcher_exception import PatcherException  # noqa: F401
+from . import BaseHotnessException
+
+
+class ConnectionException(BaseHotnessException):
+    """
+    Class representing connection exception.
+    This exception is raised when temporary
+    connection error happens. It is being used
+    to recognize that the message should be put
+    back in the queue till the error is resolved.
+
+    Attributes:
+        message: Error message.
+    """
+
+    def __init__(self):
+        """
+        Class constructor.
+        """
+        self.message = ""
+        super(ConnectionException, self).__init__(self.message)

--- a/hotness/hotness_consumer.py
+++ b/hotness/hotness_consumer.py
@@ -30,6 +30,7 @@ from hotness.config import config
 from hotness.domain import Package
 from hotness.builders import Koji
 from hotness.databases import Redis
+from hotness.exceptions import ConnectionException
 from hotness.notifiers import Bugzilla as bz_notifier, FedoraMessaging
 from hotness.patchers import Bugzilla as bz_patcher
 from hotness.validators import MDApi, Pagure
@@ -197,7 +198,7 @@ class HotnessConsumer(object):
                 self._handle_anitya_version_update(message)
             elif topic.endswith("buildsys.task.state.change"):
                 self._handle_buildsys_scratch(msg)
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+        except ConnectionException as e:
             # This catches Timeout and ConnectionError (transient network issues)
             _logger.warning(
                 "Transient network error processing message %s: %s. "
@@ -453,22 +454,9 @@ class HotnessConsumer(object):
                     )
 
                     # Failure happened when communicating with bugzilla
+                    # Don't drop the message just raise the exception
                     if bz_id == -1:
-                        opts = {
-                            "body": {
-                                "trigger": {
-                                    "msg": message.body,
-                                    "topic": message.topic,
-                                },
-                                "reason": "bugzilla",
-                            }
-                        }
-
-                        notify_request = NotifyRequest(
-                            package=package, message="update.drop", opts=opts
-                        )
-                        fedora_messaging_use_case.notify(notify_request)
-                        return
+                        raise ConnectionException()
 
                 # Send Fedora messaging notification
                 # This will have bz_id = -1 if there isn't any bugzilla ticket filled

--- a/hotness/use_cases/package_check_use_case.py
+++ b/hotness/use_cases/package_check_use_case.py
@@ -19,6 +19,7 @@ import logging
 
 import requests
 
+from hotness.exceptions import ConnectionException
 from hotness.validators import Validator
 from hotness.requests.package_request import PackageRequest
 from hotness import responses
@@ -62,7 +63,7 @@ class PackageCheckUseCase:
             return responses.ResponseSuccess(result)
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             # Re-raise only connectivity/timeouts so they can be retried
-            raise
+            raise ConnectionException()
         except Exception as exc:
             logger.exception("Package check use case failure", exc_info=True)
             return responses.ResponseFailure.validator_error(exc)

--- a/news/229.feature
+++ b/news/229.feature
@@ -1,0 +1,2 @@
+Make the-new-hotness more reliable by re-queuing received message when temporary error happens
+

--- a/tests/test_hotness_consumer.py
+++ b/tests/test_hotness_consumer.py
@@ -24,6 +24,8 @@ import traceback
 from unittest import mock
 
 from fedora_messaging.message import Message
+from fedora_messaging import exceptions as fm_exceptions
+
 
 from hotness.hotness_consumer import HotnessConsumer
 from hotness.domain import Package
@@ -1365,7 +1367,8 @@ class TestHotnessConsumerCall:
         }
         self.consumer.notifier_bugzilla.notify.side_effect = Exception()
 
-        self.consumer.__call__(message)
+        with pytest.raises(fm_exceptions.Nack):
+            self.consumer.__call__(message)
 
         package = Package(name="flatpak", version="1.0.4", distro="Fedora")
 
@@ -1388,17 +1391,6 @@ class TestHotnessConsumerCall:
                 dist_git_url=self.consumer.dist_git_url + "/rpms/" + package.name,
             ),
             {"bz_short_desc": "flatpak-1.0.4 is available"},
-        )
-
-        exp_opts = {
-            "body": {
-                "trigger": {"msg": message.body, "topic": message.topic},
-                "reason": "bugzilla",
-            }
-        }
-
-        self.consumer.notifier_fedora_messaging.notify.assert_called_with(
-            package, "update.drop", exp_opts
         )
 
     def test_call_anitya_update_no_bugzilla(self):
@@ -1703,7 +1695,6 @@ class TestHotnessConsumerCall:
         Assert that transient network errors raise Nack to retry the message.
         """
         import requests
-        from fedora_messaging import exceptions as fm_exceptions
 
         message = create_message("anitya.project.version.update.v2", "fedora_mapping")
         # Simulate a network connection error (transient)

--- a/tests/use_cases/test_package_check_use_case.py
+++ b/tests/use_cases/test_package_check_use_case.py
@@ -15,8 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+import pytest
+import requests
 from unittest import mock
 
+from hotness.exceptions import ConnectionException
 from hotness.use_cases.package_check_use_case import PackageCheckUseCase
 from hotness import responses
 
@@ -136,3 +139,22 @@ class TestPackageCheckUseCaseValidate:
             "message": "Exception: This is heresy!",
             "use_case_value": None,
         }
+
+    def test_validate_connection_error(self):
+        """
+        Assert that the validation is called correctly and exception is
+        raised when connection error happens.
+        """
+        validator = mock.Mock()
+        validator.validate.side_effect = requests.exceptions.ConnectionError()
+
+        package = mock.Mock()
+        request = mock.Mock()
+        request.package = package
+
+        use_case = PackageCheckUseCase(validator=validator)
+
+        with pytest.raises(ConnectionException):
+            use_case.validate(request)
+
+        validator.validate.assert_called_with(package)


### PR DESCRIPTION
When connection error on bugzilla happens just return the Anitya message back to queue and not drop it.

Fixes #229